### PR TITLE
Typesafe operations for controlling find() queries

### DIFF
--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -13,6 +13,7 @@
 // Contributors:
 //     Linda DeMichiel - 2.1
 //     Linda DeMichiel - 2.0
+//     Gavin King - 3.2
 
 
 package jakarta.persistence;
@@ -105,7 +106,7 @@ public interface EntityManager extends AutoCloseable {
      *         not exist
      * @throws IllegalArgumentException if the first argument does
      *         not denote an entity type or the second argument is 
-     *         is not a valid type for that entity's primary key or
+     *         not a valid type for that entity's primary key or
      *         is null
      */
     public <T> T find(Class<T> entityClass, Object primaryKey);
@@ -125,7 +126,7 @@ public interface EntityManager extends AutoCloseable {
      *         not exist 
      * @throws IllegalArgumentException if the first argument does 
      *         not denote an entity type or the second argument is
-     *         is not a valid type for that entity's primary key or 
+     *         not a valid type for that entity's primary key or
      *         is null 
      * @since 2.0
      */ 
@@ -256,7 +257,17 @@ public interface EntityManager extends AutoCloseable {
      *         cannot be accessed
      */
     public <T> T getReference(Class<T> entityClass, 
-                                  Object primaryKey);
+                              Object primaryKey);
+
+    /**
+     * Obtain an instance of {@link Find} for executing queries
+     * by primary key.
+     * @param entityClass  entity class
+     * @return an instance of {@link Find}
+     * @throws IllegalArgumentException if the argument does not
+     *         denote an entity type
+     */
+    public <T> Find<T> find(Class<T> entityClass);
 
     /**
      * Synchronize the persistence context to the

--- a/api/src/main/java/jakarta/persistence/Find.java
+++ b/api/src/main/java/jakarta/persistence/Find.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Gavin King  - 3.2
+
+package jakarta.persistence;
+
+import java.util.List;
+
+/**
+ * Interface used to control execution of queries by primary key.
+ * @param <T> the entity type
+ */
+public interface Find<T> {
+
+	/**
+	 * Find by primary key, using any specified entity graph,
+	 * cache modes, lock mode, hints, and properties, returning
+	 * a single entity with the given identifier value.
+	 * This operation differs from {@link #getSingleResult(Object)}
+	 * in returning null if no entity is found.
+	 * @param primaryKey primary key
+	 * @return the found entity instance or null if the entity
+	 *         does not exist
+	 * @throws IllegalArgumentException if the argument is not
+	 *         a valid type for the entity's primary key or
+	 *         is null
+	 * @throws QueryTimeoutException if the query execution exceeds
+	 *         the query timeout value set and only the statement is
+	 *         rolled back
+	 * @throws TransactionRequiredException if a lock mode other than
+	 *         <code>NONE</code> has been set and there is no transaction
+	 *         or the persistence context has not been joined to the
+	 *         transaction
+	 * @throws PessimisticLockException if pessimistic locking
+	 *         fails and the transaction is rolled back
+	 * @throws LockTimeoutException if pessimistic locking
+	 *         fails and only the statement is rolled back
+	 * @throws PersistenceException if the query execution exceeds
+	 *         the query timeout value set and the transaction
+	 *         is rolled back
+	 */
+	T find(Object primaryKey);
+
+	/**
+	 * Find by primary key, using any specified entity graph,
+	 * cache modes, lock mode, hints, and properties, returning
+	 * a single entity with the given identifier value.
+	 * This operation differs from {@link #find(Object)} in
+	 * throwing a {@link NoResultException} if no entity is found.
+	 * @param primaryKey primary key
+	 * @return the found entity instance
+	 * @throws NoResultException if there is no result
+	 * @throws IllegalArgumentException if the argument is not
+	 *         a valid type for the entity's primary key or
+	 *         is null
+	 * @throws QueryTimeoutException if the query execution exceeds
+	 *         the query timeout value set and only the statement is
+	 *         rolled back
+	 * @throws TransactionRequiredException if a lock mode other than
+	 *         <code>NONE</code> has been set and there is no transaction
+	 *         or the persistence context has not been joined to the
+	 *         transaction
+	 * @throws PessimisticLockException if pessimistic locking
+	 *         fails and the transaction is rolled back
+	 * @throws LockTimeoutException if pessimistic locking
+	 *         fails and only the statement is rolled back
+	 * @throws PersistenceException if the query execution exceeds
+	 *         the query timeout value set and the transaction
+	 *         is rolled back
+	 */
+	T getSingleResult(Object primaryKey);
+
+	/**
+	 * Find by primary key, using any specified entity graph,
+	 * cache modes, lock mode, hints, and properties, returning
+	 * a list of entities with the given identifier values.
+	 * @return a list of found entity instances
+	 * @throws IllegalArgumentException if the argument is not
+	 *         a valid type for the entity's primary key or
+	 *         is null
+	 * @throws QueryTimeoutException if the query execution exceeds
+	 *         the query timeout value set and only the statement is
+	 *         rolled back
+	 * @throws TransactionRequiredException if a lock mode other than
+	 *         <code>NONE</code> has been set and there is no transaction
+	 *         or the persistence context has not been joined to the
+	 *         transaction
+	 * @throws PessimisticLockException if pessimistic locking
+	 *         fails and the transaction is rolled back
+	 * @throws LockTimeoutException if pessimistic locking
+	 *         fails and only the statement is rolled back
+	 * @throws PersistenceException if the query execution exceeds
+	 *         the query timeout value set and the transaction
+	 *         is rolled back
+	 */
+	List<T> getResultList(Object... primaryKeys);
+
+	/**
+	 * Find by primary key, using any specified entity graph,
+	 * cache modes, lock mode, hints, and properties, returning
+	 * a list of entities with the given identifier values.
+	 * @return a list of found entity instances
+	 * @throws IllegalArgumentException if the argument is not
+	 *         a valid type for the entity's primary key or
+	 *         is null
+	 * @throws QueryTimeoutException if the query execution exceeds
+	 *         the query timeout value set and only the statement is
+	 *         rolled back
+	 * @throws TransactionRequiredException if a lock mode other than
+	 *         <code>NONE</code> has been set and there is no transaction
+	 *         or the persistence context has not been joined to the
+	 *         transaction
+	 * @throws PessimisticLockException if pessimistic locking
+	 *         fails and the transaction is rolled back
+	 * @throws LockTimeoutException if pessimistic locking
+	 *         fails and only the statement is rolled back
+	 * @throws PersistenceException if the query execution exceeds
+	 *         the query timeout value set and the transaction
+	 *         is rolled back
+	 */
+	List<T> getResultList(List<?> primaryKeys);
+
+	/**
+	 * Set a property or hint. The hints elements may be used to
+	 * specify query properties and hints. Properties defined by
+	 * this specification must be observed by the provider.
+	 * Vendor-specific hints that are not recognized by a provider
+	 * must be silently ignored. Portable applications should not
+	 * rely on the standard timeout hint. Depending on the database
+	 * in use and the locking mechanisms used by the provider,
+	 * this hint may or may not be observed.
+	 * @param hintName  name of property or hint
+	 * @param value  value for the property or hint
+	 * @return the same query instance
+	 * @throws IllegalArgumentException if the second argument is not
+	 *         valid for the implementation
+	 */
+	Find<T> setHint(String hintName, Object value);
+
+	/**
+	 * Set a fetch graph to be applied to the entity returned by
+	 * this query.
+	 * @param fetchGraph an entity graph to be interpreted as a
+	 *                   fetch graph
+	 * @return the same query instance
+	 */
+	Find<T> setFetchGraph(EntityGraph<? super T> fetchGraph);
+
+	/**
+	 * Set a load graph to be applied to the entity returned by
+	 * this query.
+	 * @param loadGraph an entity graph to be interpreted as a
+	 *                  load graph
+	 * @return the same query instance
+	 */
+	Find<T> setLoadGraph(EntityGraph<? super T> loadGraph);
+
+	/**
+	 * Set the cache retrieval mode that is in effect during
+	 * query execution. This cache retrieval mode overrides the
+	 * cache retrieve mode in use by the entity manager.
+	 * @param cacheRetrieveMode cache retrieval mode
+	 * @return the same query instance
+	 */
+	Find<T> setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+	/**
+	 * Set the cache storage mode that is in effect during
+	 * query execution. This cache storage mode overrides the
+	 * cache storage mode in use by the entity manager.
+	 * @param cacheStoreMode cache storage mode
+	 * @return the same query instance
+	 */
+	Find<T> setCacheStoreMode(CacheStoreMode cacheStoreMode);
+
+	/**
+	 * Set the lock mode type to be used for the query execution.
+	 * @param lockMode  lock mode
+	 * @return the same query instance
+	 * @throws IllegalStateException if the query is found not to
+	 *         be a Jakarta Persistence query language SELECT query
+	 *         or a CriteriaQuery query
+	 */
+	Find<T> setLockMode(LockModeType lockMode);
+}

--- a/api/src/main/java/jakarta/persistence/Find.java
+++ b/api/src/main/java/jakarta/persistence/Find.java
@@ -27,6 +27,36 @@ public interface Find<T> {
 	 * Find by primary key, using any specified entity graph,
 	 * cache modes, lock mode, hints, and properties, returning
 	 * a single entity with the given identifier value.
+	 * This operation differs from {@link #getSingleResultOrNull(Object)}
+	 * in throwing a {@link NoResultException} if no entity is found.
+	 * @param primaryKey primary key
+	 * @return the found entity instance
+	 * @throws NoResultException if there is no result
+	 * @throws IllegalArgumentException if the argument is not
+	 *         a valid type for the entity's primary key or
+	 *         is null
+	 * @throws QueryTimeoutException if the query execution exceeds
+	 *         the query timeout value set and only the statement is
+	 *         rolled back
+	 * @throws TransactionRequiredException if a lock mode other than
+	 *         <code>NONE</code> has been set and there is no transaction
+	 *         or the persistence context has not been joined to the
+	 *         transaction
+	 * @throws PessimisticLockException if pessimistic locking
+	 *         fails and the transaction is rolled back
+	 * @throws LockTimeoutException if pessimistic locking
+	 *         fails and only the statement is rolled back
+	 * @throws PersistenceException if the query execution exceeds
+	 *         the query timeout value set and the transaction
+	 *         is rolled back
+	 */
+	T getSingleResult(Object primaryKey);
+
+	/**
+	 * Find by primary key, using any specified entity graph,
+	 * cache modes, lock mode, hints, and properties, returning
+	 * a single entity with the given identifier value, or null
+	 * if no such entity is found.
 	 * This operation differs from {@link #getSingleResult(Object)}
 	 * in returning null if no entity is found.
 	 * @param primaryKey primary key
@@ -50,36 +80,7 @@ public interface Find<T> {
 	 *         the query timeout value set and the transaction
 	 *         is rolled back
 	 */
-	T find(Object primaryKey);
-
-	/**
-	 * Find by primary key, using any specified entity graph,
-	 * cache modes, lock mode, hints, and properties, returning
-	 * a single entity with the given identifier value.
-	 * This operation differs from {@link #find(Object)} in
-	 * throwing a {@link NoResultException} if no entity is found.
-	 * @param primaryKey primary key
-	 * @return the found entity instance
-	 * @throws NoResultException if there is no result
-	 * @throws IllegalArgumentException if the argument is not
-	 *         a valid type for the entity's primary key or
-	 *         is null
-	 * @throws QueryTimeoutException if the query execution exceeds
-	 *         the query timeout value set and only the statement is
-	 *         rolled back
-	 * @throws TransactionRequiredException if a lock mode other than
-	 *         <code>NONE</code> has been set and there is no transaction
-	 *         or the persistence context has not been joined to the
-	 *         transaction
-	 * @throws PessimisticLockException if pessimistic locking
-	 *         fails and the transaction is rolled back
-	 * @throws LockTimeoutException if pessimistic locking
-	 *         fails and only the statement is rolled back
-	 * @throws PersistenceException if the query execution exceeds
-	 *         the query timeout value set and the transaction
-	 *         is rolled back
-	 */
-	T getSingleResult(Object primaryKey);
+	T getSingleResultOrNull(Object primaryKey);
 
 	/**
 	 * Find by primary key, using any specified entity graph,

--- a/api/src/main/java/jakarta/persistence/Query.java
+++ b/api/src/main/java/jakarta/persistence/Query.java
@@ -14,6 +14,7 @@
 //     Lukas Jungmann  - 2.2
 //     Linda DeMichiel - 2.1
 //     Linda DeMichiel - 2.0
+//     Gavin King - 3.2
 
 package jakarta.persistence;
 

--- a/api/src/main/java/jakarta/persistence/Query.java
+++ b/api/src/main/java/jakarta/persistence/Query.java
@@ -441,6 +441,24 @@ public interface Query {
     Query setFlushMode(FlushModeType flushMode);
 
     /**
+     * Set the cache retrieval mode that is in effect during
+     * query execution. This cache retrieval mode overrides the
+     * cache retrieve mode in use by the entity manager.
+     * @param cacheRetrieveMode cache retrieval mode
+     * @return the same query instance
+     */
+    Query setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+    /**
+     * Set the cache storage mode that is in effect during
+     * query execution. This cache storage mode overrides the
+     * cache storage mode in use by the entity manager.
+     * @param cacheStoreMode cache storage mode
+     * @return the same query instance
+     */
+    Query setCacheStoreMode(CacheStoreMode cacheStoreMode);
+
+    /**
      * Get the flush mode in effect for the query execution. 
      * If a flush mode has not been set for the query object, 
      * returns the flush mode in effect for the entity manager.

--- a/api/src/main/java/jakarta/persistence/Query.java
+++ b/api/src/main/java/jakarta/persistence/Query.java
@@ -113,6 +113,29 @@ public interface Query {
     Object getSingleResult();
 
     /**
+     * Execute a SELECT query that returns a single untyped result,
+     * or null if there is no result.
+     * @return the result
+     * @throws NonUniqueResultException if more than one result
+     * @throws IllegalStateException if called for a Jakarta
+     *         Persistence query language UPDATE or DELETE statement
+     * @throws QueryTimeoutException if the query execution exceeds
+     *         the query timeout value set and only the statement is
+     *         rolled back
+     * @throws TransactionRequiredException if a lock mode other than
+     *         <code>NONE</code> has been set and there is no transaction
+     *         or the persistence context has not been joined to the transaction
+     * @throws PessimisticLockException if pessimistic locking
+     *         fails and the transaction is rolled back
+     * @throws LockTimeoutException if pessimistic locking
+     *         fails and only the statement is rolled back
+     * @throws PersistenceException if the query execution exceeds
+     *         the query timeout value set and the transaction
+     *         is rolled back
+     */
+    Object getSingleResultOrNull();
+
+    /**
      * Execute an update or delete statement.
      * @return the number of entities updated or deleted
      * @throws IllegalStateException if called for a Jakarta

--- a/api/src/main/java/jakarta/persistence/StoredProcedureQuery.java
+++ b/api/src/main/java/jakarta/persistence/StoredProcedureQuery.java
@@ -243,6 +243,24 @@ public interface StoredProcedureQuery extends Query {
     StoredProcedureQuery setFlushMode(FlushModeType flushMode);
 
     /**
+     * Set the cache retrieval mode that is in effect during
+     * query execution. This cache retrieval mode overrides the
+     * cache retrieve mode in use by the entity manager.
+     * @param cacheRetrieveMode cache retrieval mode
+     * @return the same query instance
+     */
+    StoredProcedureQuery setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+    /**
+     * Set the cache storage mode that is in effect during
+     * query execution. This cache storage mode overrides the
+     * cache storage mode in use by the entity manager.
+     * @param cacheStoreMode cache storage mode
+     * @return the same query instance
+     */
+    StoredProcedureQuery setCacheStoreMode(CacheStoreMode cacheStoreMode);
+
+    /**
      * Register a positional parameter.
      * All parameters must be registered.
      * @param position  parameter position

--- a/api/src/main/java/jakarta/persistence/StoredProcedureQuery.java
+++ b/api/src/main/java/jakarta/persistence/StoredProcedureQuery.java
@@ -12,6 +12,7 @@
 
 // Contributors:
 //     Linda DeMichiel - 2.1
+//     Gavin King - 3.2
 
 package jakarta.persistence;
 

--- a/api/src/main/java/jakarta/persistence/TypedQuery.java
+++ b/api/src/main/java/jakarta/persistence/TypedQuery.java
@@ -14,6 +14,7 @@
 //     Lukas Jungmann  - 2.2
 //     Linda DeMichiel - 2.1
 //     Linda DeMichiel - 2.0
+//     Gavin King - 3.2
 
 package jakarta.persistence;
 
@@ -32,6 +33,8 @@ import java.util.stream.Stream;
  * @since 2.0
  */
 public interface TypedQuery<X> extends Query {
+
+
 	
     /**
      * Execute a SELECT query and return the query results

--- a/api/src/main/java/jakarta/persistence/TypedQuery.java
+++ b/api/src/main/java/jakarta/persistence/TypedQuery.java
@@ -265,6 +265,24 @@ public interface TypedQuery<X> extends Query {
       */
      TypedQuery<X> setFlushMode(FlushModeType flushMode);
 
+    /**
+     * Set the cache retrieval mode that is in effect during
+     * query execution. This cache retrieval mode overrides the
+     * cache retrieve mode in use by the entity manager.
+     * @param cacheRetrieveMode cache retrieval mode
+     * @return the same query instance
+     */
+    TypedQuery<X> setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+    /**
+     * Set the cache storage mode that is in effect during
+     * query execution. This cache storage mode overrides the
+     * cache storage mode in use by the entity manager.
+     * @param cacheStoreMode cache storage mode
+     * @return the same query instance
+     */
+    TypedQuery<X> setCacheStoreMode(CacheStoreMode cacheStoreMode);
+    
      /**
       * Set the lock mode type to be used for the query execution.
       * @param lockMode  lock mode

--- a/api/src/main/java/jakarta/persistence/TypedQuery.java
+++ b/api/src/main/java/jakarta/persistence/TypedQuery.java
@@ -256,6 +256,24 @@ public interface TypedQuery<X> extends Query {
     TypedQuery<X> setParameter(int position, Date value,  
                                TemporalType temporalType);
 
+    /**
+     * Set a fetch graph to be applied to the entity returned by
+     * this query.
+     * @param fetchGraph an entity graph to be interpreted as a
+     *                   fetch graph
+     * @return the same query instance
+     */
+    TypedQuery<X> setFetchGraph(EntityGraph<? super X> fetchGraph);
+
+    /**
+     * Set a load graph to be applied to the entity returned by
+     * this query.
+     * @param loadGraph an entity graph to be interpreted as a
+     *                  load graph
+     * @return the same query instance
+     */
+    TypedQuery<X> setLoadGraph(EntityGraph<? super X> loadGraph);
+
      /**
       * Set the flush mode type to be used for the query execution.
       * The flush mode type applies to the query regardless of the
@@ -282,7 +300,7 @@ public interface TypedQuery<X> extends Query {
      * @return the same query instance
      */
     TypedQuery<X> setCacheStoreMode(CacheStoreMode cacheStoreMode);
-    
+
      /**
       * Set the lock mode type to be used for the query execution.
       * @param lockMode  lock mode


### PR DESCRIPTION
See #383.

- Added the `Find` interface.
- Also added a way to set the cache modes for a `Query`, and the `EntityGraph` for a `TypedQuery`.