### PR TITLE
Proposal to fix signatures of operations of entity graphs

### DIFF
--- a/api/src/main/java/jakarta/persistence/AbstractGraph.java
+++ b/api/src/main/java/jakarta/persistence/AbstractGraph.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Gavin King - 3.2
+
+package jakarta.persistence;
+
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.MapAttribute;
+import jakarta.persistence.metamodel.PluralAttribute;
+
+import java.util.List;
+
+/**
+ * Declares operations common to {@link EntityGraph} and {@link Subgraph}.
+ *
+ * @since 6.3
+ */
+public interface AbstractGraph<T> {
+
+    /**
+     * Add an attribute nodes to the entity graph.
+     *
+     * @param attributeName  name of the attribute
+     * @throws IllegalArgumentException if the attribute is not an
+     *         attribute of this entity.
+     * @throws IllegalStateException if the EntityGraph has been
+     *         statically defined
+     *
+     * @since 6.3
+     */
+    public void addAttributeNode(String attributeName);
+
+    /**
+     * Add an attribute node to the entity graph.
+     *
+     * @param attribute  attribute
+     * @throws IllegalStateException if the EntityGraph has been
+     *         statically defined
+     *
+     * @since 6.3
+     */
+    public void addAttributeNode(Attribute<T, ?> attribute);
+
+    /**
+     * Add one or more attribute nodes to the entity graph.
+     *
+     * @param attributeName  name of the attribute
+     * @throws IllegalArgumentException if the attribute is not an
+     *         attribute of this entity.
+     * @throws IllegalStateException if the EntityGraph has been
+     *         statically defined
+     */
+    public void addAttributeNodes(String... attributeName);
+
+    /**
+     * Add one or more attribute nodes to the entity graph.
+     *
+     * @param attribute  attribute
+     * @throws IllegalStateException if the EntityGraph has been
+     *         statically defined
+     */
+    public void addAttributeNodes(Attribute<T, ?>... attribute);
+
+    /**
+     * Add a node to the graph that corresponds to a managed
+     * type. This allows for construction of multi-node entity graphs
+     * that include related managed types.
+     *
+     * @param attribute  attribute
+     * @return subgraph for the attribute
+     * @throws IllegalArgumentException if the attribute's target type
+     *         is not a managed type
+     * @throws IllegalStateException if the EntityGraph has been
+     *         statically defined
+     */
+    public <X> Subgraph<X> addSubgraph(Attribute<? super T, X> attribute);
+
+    /**
+     * Add a node to the graph that corresponds to a managed
+     * type with inheritance.  This allows for multiple subclass
+     * subgraphs to be defined for this node of the entity
+     * graph. Subclass subgraphs will automatically include the
+     * specified attributes of superclass subgraphs.
+     *
+     * @param attribute  attribute
+     * @param type  entity subclass
+     * @return subgraph for the attribute
+     * @throws IllegalArgumentException if the attribute's target
+     *         type is not a managed type
+     * @throws IllegalStateException if the EntityGraph has been
+     *         statically defined
+     *
+     * @since 6.3
+     */
+    public <X, Y extends X> Subgraph<Y> addTreatedSubgraph(Attribute<? super T, X> attribute, Class<Y> type);
+
+    /**
+     * Add a node to the graph that corresponds to a managed
+     * type with inheritance.  This allows for multiple subclass
+     * subgraphs to be defined for this node of the entity
+     * graph. Subclass subgraphs will automatically include the
+     * specified attributes of superclass subgraphs.
+     *
+     * @param attribute  attribute
+     * @param type  entity subclass
+     * @return subgraph for the attribute
+     * @throws IllegalArgumentException if the attribute's target
+     *         type is not a managed type
+     * @throws IllegalStateException if the EntityGraph has been
+     *         statically defined
+     * @deprecated use {@link #addTreatedSubgraph(Attribute, Class)}
+     */
+    @Deprecated(since = "3.2")
+    public <X> Subgraph<? extends X> addSubgraph(Attribute<T, X> attribute, Class<? extends X> type);
+
+    /**
+     * Add a node to the graph that corresponds to a managed
+     * type. This allows for construction of multi-node entity graphs
+     * that include related managed types.
+     *
+     * @param attributeName  name of the attribute
+     * @return subgraph for the attribute
+     * @throws IllegalArgumentException if the attribute is not an
+     *         attribute of this entity.
+     * @throws IllegalArgumentException if the attribute's target type
+     *         is not a managed type
+     * @throws IllegalStateException if the EntityGraph has been
+     *         statically defined
+     */
+    public <X> Subgraph<X> addSubgraph(String attributeName);
+
+    /**
+     * Add a node to the graph that corresponds to a managed
+     * type with inheritance.  This allows for multiple subclass
+     * subgraphs to be defined for this node of the entity graph.
+     * Subclass subgraphs will automatically include the specified
+     * attributes of superclass subgraphs.
+     *
+     * @param attributeName  name of the attribute
+     * @param type  entity subclass
+     * @return subgraph for the attribute
+     * @throws IllegalArgumentException if the attribute is not an
+     *         attribute of this managed type.
+     * @throws IllegalArgumentException if the attribute's target type
+     *         is not a managed type
+     * @throws IllegalStateException if this EntityGraph has been
+     *         statically defined
+     */
+    public <X> Subgraph<X> addSubgraph(String attributeName, Class<X> type);
+
+    /**
+     * Add a node to the graph that corresponds to a collection element
+     * that is a managed type. This allows for construction of
+     * multi-node entity graphs that include related managed types.
+     *
+     * @param attribute  attribute
+     * @return subgraph for the key attribute
+     * @throws IllegalArgumentException if the attribute's target type
+     *         is not an entity
+     * @throws IllegalStateException if this EntityGraph has been
+     *         statically defined
+     *
+     * @since 3.2
+     */
+    public <E> Subgraph<E> addElementSubgraph(PluralAttribute<T, ?, E> attribute);
+
+    /**
+     * Add a node to the graph that corresponds to a collection element
+     * that is a managed type. This allows for construction of
+     * multi-node entity graphs that include related managed types.
+     *
+     * @param attribute  attribute
+     * @return subgraph for the key attribute
+     * @throws IllegalArgumentException if the attribute's target type
+     *         is not an entity
+     * @throws IllegalStateException if this EntityGraph has been
+     *         statically defined
+     *
+     * @since 3.2
+     */
+    public <E, F extends E> Subgraph<F> addElementSubgraph(PluralAttribute<T, ?, E> attribute, Class<F> type);
+
+    /**
+     * Add a node to the graph that corresponds to a map key
+     * that is a managed type. This allows for construction of
+     * multi-node entity graphs that include related managed types.
+     *
+     * @param attribute  attribute
+     * @return subgraph for the key attribute
+     * @throws IllegalArgumentException if the attribute's target type
+     *         is not an entity
+     * @throws IllegalStateException if this EntityGraph has been
+     *         statically defined
+     *
+     * @since 3.2
+     */
+    public <K> Subgraph<K> addKeySubgraph(MapAttribute<T, K, ?> attribute);
+
+    /**
+     * Add a node to the graph that corresponds to a map key
+     * that is a managed type with inheritance. This allows for
+     * construction of multi-node entity graphs that include related
+     * managed types.  Subclass subgraphs will include the specified
+     * attributes of superclass subgraphs.
+     *
+     * @param attribute  attribute
+     * @param type  entity subclass
+     * @return subgraph for the key attribute
+     * @throws IllegalArgumentException if the attribute's target type
+     *         is not an entity
+     * @throws IllegalStateException if this EntityGraph has been
+     *         statically defined
+     *
+     * @since 3.2
+     */
+    public <K, J extends K> Subgraph<J> addTreatedKeySubgraph(MapAttribute<? super T, K, ?> attribute, Class<J> type);
+
+    /**
+     * Add a node to the graph that corresponds to a map key
+     * that is a managed type. This allows for construction of
+     * multi-node entity graphs that include related managed types.
+     *
+     * @param attribute  attribute
+     * @return subgraph for the key attribute
+     * @throws IllegalArgumentException if the attribute's target type
+     *         is not an entity
+     * @throws IllegalStateException if this EntityGraph has been
+     *         statically defined
+     * @deprecated the signature of this method is incorrect,
+     *             use {@link #addKeySubgraph(MapAttribute)}
+     */
+    @Deprecated(since = "3.2")
+    public <X> Subgraph<X> addKeySubgraph(Attribute<T, X> attribute);
+
+    /**
+     * Add a node to the graph that corresponds to a map key
+     * that is a managed type with inheritance. This allows for
+     * construction of multi-node entity graphs that include related
+     * managed types.  Subclass subgraphs will include the specified
+     * attributes of superclass subgraphs.
+     *
+     * @param attribute  attribute
+     * @param type  entity subclass
+     * @return subgraph for the key attribute
+     * @throws IllegalArgumentException if the attribute's target type
+     *         is not an entity
+     * @throws IllegalStateException if this EntityGraph has been
+     *         statically defined
+     * @deprecated the signature of this method is incorrect,
+     *             use {@link #addTreatedKeySubgraph(MapAttribute, Class)}
+     */
+    @Deprecated(since = "3.2")
+    public <X> Subgraph<? extends X> addKeySubgraph(Attribute<? super T, X> attribute, Class<? extends X> type);
+
+    /**
+     * Add a node to the graph that corresponds to a map key
+     * that is a managed type. This allows for construction of
+     * multi-node entity graphs that include related managed types.
+     *
+     * @param attributeName  name of the attribute
+     * @return subgraph for the key attribute
+     * @throws IllegalArgumentException if the attribute is not an
+     *         attribute of this entity.
+     * @throws IllegalArgumentException if the attribute's target type
+     *         is not an entity
+     * @throws IllegalStateException if this EntityGraph has been
+     *          statically defined
+     */
+    public <X> Subgraph<X> addKeySubgraph(String attributeName);
+
+    /**
+     * Add a node to the graph that corresponds to a map key
+     * that is a managed type with inheritance. This allows for
+     * construction of multi-node entity graphs that include related
+     * managed types. Subclass subgraphs will automatically include
+     * the specified attributes of superclass subgraphs
+     *
+     * @param attributeName  name of the attribute
+     * @param type  entity subclass
+     * @return subgraph for the key attribute
+     * @throws IllegalArgumentException if the attribute is not an
+     *         attribute of this entity.
+     * @throws IllegalArgumentException if the attribute's target type
+     *         is not a managed type
+     * @throws IllegalStateException if this EntityGraph has been
+     *         statically defined
+     */
+    public <X> Subgraph<X> addKeySubgraph(String attributeName, Class<X> type);
+
+    /**
+     * Add additional attributes to this entity graph that
+     * correspond to attributes of subclasses of this EntityGraph's
+     * entity type.  Subclass subgraphs will automatically include the
+     * specified attributes of superclass subgraphs.
+     *
+     * @param type  entity subclass
+     * @return subgraph for the subclass
+     * @throws IllegalArgumentException if the type is not an entity type
+     * @throws IllegalStateException if the EntityGraph has been
+     *         statically defined
+     */
+    public <S extends T> Subgraph<S> addTreatedSubgraph(Class<S> type);
+
+    /**
+     * Add additional attributes to this entity graph that
+     * correspond to attributes of subclasses of this EntityGraph's
+     * entity type.  Subclass subgraphs will automatically include the
+     * specified attributes of superclass subgraphs.
+     *
+     * @param type  entity subclass
+     * @return subgraph for the subclass
+     * @throws IllegalArgumentException if the type is not an entity type
+     * @throws IllegalStateException if the EntityGraph has been
+     *         statically defined
+     * @deprecated use {@link #addTreatedSubgraph(Class)}
+     */
+    @Deprecated(since = "3.2")
+    public <S> Subgraph<? extends S> addSubclassSubgraph(Class<? extends S> type);
+
+    /**
+     * Return the attribute nodes of this entity that are included in
+     * the graph.
+     * @return attribute nodes for the annotated type or empty list if
+     *         none have been defined
+     */
+    public List<AttributeNode<?>> getAttributeNodes();
+}

--- a/api/src/main/java/jakarta/persistence/EntityGraph.java
+++ b/api/src/main/java/jakarta/persistence/EntityGraph.java
@@ -12,11 +12,9 @@
 
 // Contributors:
 //     Linda DeMichiel - 2.1
+//     Gavin King - 3.2
 
 package jakarta.persistence;
-
-import jakarta.persistence.metamodel.Attribute;
-import java.util.List;
 
 /**
  * This type represents the root of an entity graph that will be used
@@ -36,7 +34,7 @@ import java.util.List;
  *
  * @since 2.1
  */
-public interface EntityGraph<T> {
+public interface EntityGraph<T> extends AbstractGraph<T> {
 
     /**
      * Return the name of a named EntityGraph (an entity graph
@@ -46,181 +44,5 @@ public interface EntityGraph<T> {
      * EntityGraph is not a named EntityGraph.
      */
     public String getName();
-
-    /**
-     * Add one or more attribute nodes to the entity graph.
-     *
-     * @param attributeName  name of the attribute
-     * @throws IllegalArgumentException if the attribute is not an 
-     *         attribute of this entity.
-     * @throws IllegalStateException if the EntityGraph has been 
-     *         statically defined
-     */
-    public void addAttributeNodes(String ... attributeName);
-
-    /**
-     * Add one or more attribute nodes to the entity graph.
-     *
-     * @param attribute  attribute
-     * @throws IllegalStateException if the EntityGraph has been 
-     *         statically defined
-     */
-    public void addAttributeNodes(Attribute<T, ?>... attribute);
-
-    /**
-     * Add a node to the graph that corresponds to a managed
-     * type. This allows for construction of multi-node entity graphs
-     * that include related managed types.  
-     *
-     * @param attribute  attribute
-     * @return subgraph for the attribute
-     * @throws IllegalArgumentException if the attribute's target type 
-     *         is not a managed type
-     * @throws IllegalStateException if the EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<X> addSubgraph(Attribute<T, X> attribute);
-
-    /**
-     * Add a node to the graph that corresponds to a managed
-     * type with inheritance.  This allows for multiple subclass
-     * subgraphs to be defined for this node of the entity
-     * graph. Subclass subgraphs will automatically include the
-     * specified attributes of superclass subgraphs. 
-     *
-     * @param attribute  attribute
-     * @param type  entity subclass
-     * @return subgraph for the attribute
-     * @throws IllegalArgumentException if the attribute's target 
-     *         type is not a managed type
-     * @throws IllegalStateException if the EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<? extends X> addSubgraph(Attribute<T, X> attribute, Class<? extends X> type);
-
-    /**
-     * Add a node to the graph that corresponds to a managed
-     * type. This allows for construction of multi-node entity graphs
-     * that include related managed types.  
-     *
-     * @param attributeName  name of the attribute 
-     * @return subgraph for the attribute
-     * @throws IllegalArgumentException if the attribute is not an 
-     *         attribute of this entity.
-     * @throws IllegalArgumentException if the attribute's target type 
-     *         is not a managed type
-     * @throws IllegalStateException if the EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<X> addSubgraph(String attributeName);
-
-    /**
-     * Add a node to the graph that corresponds to a managed
-     * type with inheritance.  This allows for multiple subclass
-     * subgraphs to be defined for this node of the entity graph.
-     * Subclass subgraphs will automatically include the specified
-     * attributes of superclass subgraphs.  
-     *
-     * @param attributeName  name of the attribute 
-     * @param type  entity subclass
-     * @return subgraph for the attribute
-     * @throws IllegalArgumentException if the attribute is not an 
-     *         attribute of this managed type.
-     * @throws IllegalArgumentException if the attribute's target type 
-     *         is not a managed type
-     * @throws IllegalStateException if this EntityGraph has been
-     *         statically defined
-     */
-    public <X> Subgraph<X> addSubgraph(String attributeName, Class<X> type);
-
-    /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type. This allows for construction of
-     * multi-node entity graphs that include related managed types.
-     *
-     * @param attribute  attribute
-     * @return subgraph for the key attribute
-     * @throws IllegalArgumentException if the attribute's target type 
-     *         is not an entity
-     * @throws IllegalStateException if this EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<X> addKeySubgraph(Attribute<T, X> attribute);
-
-    /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type with inheritance. This allows for
-     * construction of multi-node entity graphs that include related
-     * managed types.  Subclass subgraphs will include the specified
-     * attributes of superclass subgraphs.
-     *
-     * @param attribute  attribute
-     * @param type  entity subclass
-     * @return subgraph for the key attribute
-     * @throws IllegalArgumentException if the attribute's target type 
-     *         is not an entity
-     * @throws IllegalStateException if this EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<? extends X> addKeySubgraph(Attribute<T, X> attribute, Class<? extends X> type);
-
-    /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type. This allows for construction of
-     * multi-node entity graphs that include related managed types.
-     *
-     * @param attributeName  name of the attribute
-     * @return subgraph for the key attribute
-     * @throws IllegalArgumentException if the attribute is not an 
-     *         attribute of this entity.
-     * @throws IllegalArgumentException if the attribute's target type 
-     *         is not an entity
-     * @throws IllegalStateException if this EntityGraph has been
-     *          statically defined
-     */
-    public <X> Subgraph<X> addKeySubgraph(String attributeName);
-
-    /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type with inheritance. This allows for
-     * construction of multi-node entity graphs that include related
-     * managed types. Subclass subgraphs will automatically include
-     * the specified attributes of superclass subgraphs
-     *
-     * @param attributeName  name of the attribute
-     * @param type  entity subclass
-     * @return subgraph for the key attribute
-     * @throws IllegalArgumentException if the attribute is not an 
-     *         attribute of this entity.
-     * @throws IllegalArgumentException if the attribute's target type 
-     *         is not a managed type
-     * @throws IllegalStateException if this EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<X> addKeySubgraph(String attributeName, Class<X> type);
-
-
-    /**
-     * Add additional attributes to this entity graph that
-     * correspond to attributes of subclasses of this EntityGraph's
-     * entity type.  Subclass subgraphs will automatically include the
-     * specified attributes of superclass subgraphs.
-     *
-     * @param type  entity subclass
-     * @return subgraph for the subclass
-     * @throws IllegalArgumentException if the type is not an entity type
-     * @throws IllegalStateException if the EntityGraph has been 
-     *         statically defined
-     */
-    public <T> Subgraph<? extends T> addSubclassSubgraph(Class<? extends T> type);
-
-
-    /**
-     * Return the attribute nodes of this entity that are included in
-     * the entity graph.
-     * @return attribute nodes for the annotated entity type or empty
-     *         list if none have been defined
-     */
-    public List<AttributeNode<?>> getAttributeNodes();
 
 }

--- a/api/src/main/java/jakarta/persistence/Subgraph.java
+++ b/api/src/main/java/jakarta/persistence/Subgraph.java
@@ -12,11 +12,9 @@
 
 // Contributors:
 //     Linda DeMichiel - 2.1
+//     Gavin King - 3.2
 
 package jakarta.persistence;
-
-import jakarta.persistence.metamodel.Attribute;
-import java.util.List;
 
 /**
  * This type represents a subgraph for an attribute node that
@@ -31,171 +29,12 @@ import java.util.List;
  *
  * @since 2.1
  */
-public interface Subgraph<T> {
-
-    /**
-     * Add one or more attribute nodes to the entity graph.
-     *
-     * @param attributeName  name of the attribute     
-     * @throws IllegalArgumentException if the attribute is not an 
-     *         attribute of this managed type.
-     * @throws IllegalStateException if the EntityGraph has been 
-     *         statically defined
-     */
-    public void addAttributeNodes(String ... attributeName);
-
-    /**
-     * Add one or more attribute nodes to the entity graph.
-     * @param attribute  attribute
-     *
-     * @throws IllegalStateException if this EntityGraph has been 
-     *         statically defined
-     */
-    public void addAttributeNodes(Attribute<T, ?>... attribute);
-
-    /**
-     * Add a node to the graph that corresponds to a managed
-     * type. This allows for construction of multi-node entity graphs
-     * that include related managed types.
-     *
-     * @param attribute  attribute
-     * @return subgraph for the attribute
-     * @throws IllegalArgumentException if the attribute's target 
-     *         type is not a managed type
-     * @throws IllegalStateException if the EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<X> addSubgraph(Attribute<T, X> attribute);
-
-    /**
-     * Add a node to the graph that corresponds to a managed
-     * type with inheritance.  This allows for multiple subclass
-     * subgraphs to be defined for this node of the entity
-     * graph. Subclass subgraphs will automatically include the specified
-     * attributes of superclass subgraphs
-     *
-     * @param attribute  attribute
-     * @param type  entity subclass
-     * @return subgraph for the attribute
-     * @throws IllegalArgumentException if the attribute's target 
-     *         type is not a managed type
-     * @throws IllegalStateException if this EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<? extends X> addSubgraph(Attribute<T, X> attribute, Class<? extends X> type);
-
-    /**
-     * Add a node to the graph that corresponds to a managed
-     * type. This allows for construction of multi-node entity graphs
-     * that include related managed types.
-     *
-     * @param attributeName  name of the attribute 
-     * @return subgraph for the attribute
-     * @throws IllegalArgumentException if the attribute is not an 
-     *         attribute of this managed type.
-     * @throws IllegalArgumentException if the attribute's target 
-     *         type is not a managed type
-     * @throws IllegalStateException if this EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<X> addSubgraph(String attributeName);
-
-    /**
-     * Add a node to the graph that corresponds to a managed
-     * type with inheritance.  This allows for multiple subclass
-     * subgraphs to be defined for this node of the entity
-     * graph. Subclass subgraphs will automatically include the
-     * specified attributes of superclass subgraphs
-     *
-     * @param attributeName  name of the attribute 
-     * @param type  entity subclass
-     * @return subgraph for the attribute
-     * @throws IllegalArgumentException if the attribute is not 
-     *         an attribute of this managed type.
-     * @throws IllegalArgumentException if the attribute's target 
-     *         type is not a managed type
-     * @throws IllegalStateException if this EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<X> addSubgraph(String attributeName, Class<X> type);
-
-    /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type. This allows for construction of
-     * multinode entity graphs that include related managed types.
-     *
-     * @param attribute  attribute
-     * @return subgraph for the key attribute
-     * @throws IllegalArgumentException if the attribute's target 
-     *         type is not a managed type entity
-     * @throws IllegalStateException if this EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<X> addKeySubgraph(Attribute<T, X> attribute);
-
-    /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type with inheritance. This allows for
-     * construction of multi-node entity graphs that include related
-     * managed types.  Subclass subgraphs will automatically include
-     * the specified attributes of superclass subgraphs
-     *
-     * @param attribute  attribute
-     * @param type  entity subclass
-     * @return subgraph for the attribute
-     * @throws IllegalArgumentException if the attribute's target 
-     *         type is not a managed type entity
-     * @throws IllegalStateException if this EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<? extends X> addKeySubgraph(Attribute<T, X> attribute, Class<? extends X> type);
-
-    /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type. This allows for construction of
-     * multi-node entity graphs that include related managed types.
-     *
-     * @param attributeName  name of the attribute
-     * @return subgraph for the key attribute
-     * @throws IllegalArgumentException if the attribute is not an 
-     *         attribute of this entity.
-     * @throws IllegalArgumentException if the attribute's target 
-     *         type is not a managed type
-     * @throws IllegalStateException if this EntityGraph has been
-     *          statically defined
-     */
-    public <X> Subgraph<X> addKeySubgraph(String attributeName);
-
-    /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type with inheritance. This allows for
-     * construction of multi-node entity graphs that include related
-     * managed types.  Subclass subgraphs will include the specified
-     * attributes of superclass subgraphs
-     *
-     * @param attributeName  name of the attribute
-     * @param type  entity subclass
-     * @return subgraph for the attribute
-     * @throws IllegalArgumentException if the attribute is not an 
-     *         attribute of this entity.
-     * @throws IllegalArgumentException if the attribute's target
-     *         type is not a managed type
-     * @throws IllegalStateException if this EntityGraph has been 
-     *         statically defined
-     */
-    public <X> Subgraph<X> addKeySubgraph(String attributeName, Class<X> type);
-
-    /**
-     * Return the attribute nodes corresponding to the attributes of
-     * this managed type that are included in the subgraph.
-     * @return list of attribute nodes included in the subgraph or
-     * empty List if none have been defined
-     */
-    public List<AttributeNode<?>> getAttributeNodes();
+public interface Subgraph<T> extends AbstractGraph<T> {
 
     /**
      * Return the type for which this subgraph was defined.
      * @return managed type referenced by the subgraph
      */
     public Class<T> getClassType();
+
 }


### PR DESCRIPTION
This is just a proposal to:

- fix the (I believe) incorrect signatures of some operations of `EntityGraph` and `SubGraph`, and
- introduce `AbstractGraph` as a place to declare common operations of `EntityGraph` and `SubGraph`.

See #424.