### PR TITLE
introduce FindOption interface and new overloads of EM.find()

### DIFF
--- a/api/src/main/java/jakarta/persistence/CacheRetrieveMode.java
+++ b/api/src/main/java/jakarta/persistence/CacheRetrieveMode.java
@@ -22,6 +22,9 @@ package jakarta.persistence;
  * specify the behavior when data is retrieved by the
  * <code>find</code> methods and by queries.
  *
+ * @see EntityManager#setCacheRetrieveMode(CacheRetrieveMode)
+ * @see Query#setCacheRetrieveMode(CacheRetrieveMode)
+ *
  * @since 2.0
  */
 public enum CacheRetrieveMode implements FindOption {

--- a/api/src/main/java/jakarta/persistence/CacheRetrieveMode.java
+++ b/api/src/main/java/jakarta/persistence/CacheRetrieveMode.java
@@ -24,7 +24,7 @@ package jakarta.persistence;
  *
  * @since 2.0
  */
-public enum CacheRetrieveMode {
+public enum CacheRetrieveMode implements FindOption {
 
     /**
      * Read entity data from the cache: this is 

--- a/api/src/main/java/jakarta/persistence/CacheStoreMode.java
+++ b/api/src/main/java/jakarta/persistence/CacheStoreMode.java
@@ -22,6 +22,9 @@ package jakarta.persistence;
  * the behavior when data is read from the database and when data is
  * committed into the database.
  *
+ * @see EntityManager#setCacheStoreMode(CacheStoreMode)
+ * @see Query#setCacheStoreMode(CacheStoreMode)
+ *
  * @since 2.0
  */
 public enum CacheStoreMode implements FindOption {

--- a/api/src/main/java/jakarta/persistence/CacheStoreMode.java
+++ b/api/src/main/java/jakarta/persistence/CacheStoreMode.java
@@ -24,7 +24,7 @@ package jakarta.persistence;
  *
  * @since 2.0
  */
-public enum CacheStoreMode {
+public enum CacheStoreMode implements FindOption {
 
     /**
      * Insert entity data into cache when read from database

--- a/api/src/main/java/jakarta/persistence/CacheStoreMode.java
+++ b/api/src/main/java/jakarta/persistence/CacheStoreMode.java
@@ -27,7 +27,7 @@ package jakarta.persistence;
  *
  * @since 2.0
  */
-public enum CacheStoreMode implements FindOption {
+public enum CacheStoreMode implements FindOption, RefreshOption {
 
     /**
      * Insert entity data into cache when read from database

--- a/api/src/main/java/jakarta/persistence/EntityGraph.java
+++ b/api/src/main/java/jakarta/persistence/EntityGraph.java
@@ -39,7 +39,7 @@ public interface EntityGraph<T> extends Graph<T> {
      * Return the name of a named EntityGraph (an entity graph
      * defined by means of the <code>NamedEntityGraph</code>
      * annotation, XML descriptor element, or added by means of the
-     * <code>addNamedEntityGraph</code> method.  Returns null if the
+     * <code>addNamedEntityGraph</code> method).  Returns null if the
      * EntityGraph is not a named EntityGraph.
      */
     public String getName();

--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -513,7 +513,7 @@ public interface EntityManager extends AutoCloseable {
      * @since 2.0
      */     
     public void refresh(Object entity,
-                            Map<String, Object> properties); 
+                        Map<String, Object> properties);
 
     /**
      * Refresh the state of the instance from the database, 
@@ -597,7 +597,52 @@ public interface EntityManager extends AutoCloseable {
      */
     public void refresh(Object entity, LockModeType lockMode,
                         Map<String, Object> properties);
-    
+
+    /**
+     * Refresh the state of the given entity instance from the
+     * database, using the specified {@linkplain RefreshOption options},
+     * overwriting changes made to the entity, if any. If the supplied
+     * options include a {@link LockModeType}, lock the given entity with
+     * respect to the specified lock type.
+     * <p>If the lock mode type is pessimistic and the entity instance is
+     * found but cannot be locked:
+     * <ul>
+     * <li> the <code>PessimisticLockException</code> will be thrown if
+     *      the database locking failure causes transaction-level rollback
+     * <li> the <code>LockTimeoutException</code> will be thrown if the
+     *      database locking failure causes only statement-level rollback
+     * </ul>
+     * <p>If a vendor-specific {@link RefreshOption} is not recognized,
+     * it is silently ignored.
+     * <p>Portable applications should not rely on the standard
+     * {@linkplain Timeout timeout option}. Depending on the database in
+     * use and the locking mechanisms used by the provider, the hint may
+     * or may not be observed.
+     * @param entity  entity instance
+     * @param options  standard and vendor-specific options
+     * @throws IllegalArgumentException if the instance is not an entity
+     *         or the entity is not managed
+     * @throws TransactionRequiredException if invoked on a
+     *         container-managed entity manager of type
+     *         <code>PersistenceContextType.TRANSACTION</code> when there
+     *         is no transaction; if invoked on an extended entity manager
+     *         when there is no transaction and a lock mode other than
+     *         <code>NONE</code> has been specified; or if invoked on an
+     *         extended entity manager that has not been joined to the
+     *         current transaction and a lock mode other than
+     *         <code>NONE</code> has been specified
+     * @throws EntityNotFoundException if the entity no longer exists in
+     *         the database
+     * @throws PessimisticLockException if pessimistic locking fails and
+     *         the transaction is rolled back
+     * @throws LockTimeoutException if pessimistic locking fails and only
+     *         the statement is rolled back
+     * @throws PersistenceException if an unsupported lock call is made
+     * @since 3.2
+     */
+    public void refresh(Object entity,
+                        RefreshOption... options);
+
     /**
      * Clear the persistence context, causing all managed
      * entities to become detached. Changes made to entities that

--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -481,6 +481,54 @@ public interface EntityManager extends AutoCloseable {
                      Map<String, Object> properties);
 
     /**
+     * Lock an entity instance that is contained in the persistence
+     * context with the specified lock mode type, using specified
+     * {@linkplain LockOption options}.
+     * <p>If a pessimistic lock mode type is specified and the entity
+     * contains a version attribute, the persistence provider must
+     * also perform optimistic version checks when obtaining the
+     * database lock. If these checks fail, the
+     * <code>OptimisticLockException</code> will be thrown.
+     * <p>If the lock mode type is pessimistic and the entity instance
+     * is found but cannot be locked:
+     * <ul>
+     * <li> the <code>PessimisticLockException</code> will be thrown
+     *      if the database locking failure causes transaction-level
+     *      rollback
+     * <li> the <code>LockTimeoutException</code> will be thrown if
+     *      the database locking failure causes only statement-level
+     *      rollback
+     * </ul>
+     * <p>If a vendor-specific {@link LockOption} is not recognized,
+     * it is silently ignored.
+     * <p>Portable applications should not rely on the standard
+     * {@linkplain Timeout timeout option}. Depending on the database
+     * in use and the locking mechanisms used by the provider, the
+     * option may or may not be observed.
+     * @param entity  entity instance
+     * @param lockMode  lock mode
+     * @param options  standard and vendor-specific options
+     * @throws IllegalArgumentException if the instance is not an
+     *         entity or is a detached entity
+     * @throws TransactionRequiredException if there is no
+     *         transaction or if invoked on an entity manager which
+     *         has not been joined to the current transaction
+     * @throws EntityNotFoundException if the entity does not exist
+     *         in the database when pessimistic locking is
+     *         performed
+     * @throws OptimisticLockException if the optimistic version
+     *         check fails
+     * @throws PessimisticLockException if pessimistic locking fails
+     *         and the transaction is rolled back
+     * @throws LockTimeoutException if pessimistic locking fails and
+     *         only the statement is rolled back
+     * @throws PersistenceException if an unsupported lock call is made
+     * @since 3.2
+     */
+    public void lock(Object entity, LockModeType lockMode,
+                     LockOption... options);
+
+    /**
      * Refresh the state of the instance from the database, 
      * overwriting changes made to the entity, if any. 
      * @param entity  entity instance

--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -236,6 +236,119 @@ public interface EntityManager extends AutoCloseable {
                       Map<String, Object> properties);
 
     /**
+     * Find an instance of the given entity class by primary key,
+     * using the specified {@linkplain FindOption options}.
+     * Search for an entity with the specified class and primary key.
+     * If the given options include a {@link LockModeType}, lock it
+     * with respect to the specified lock type.
+     * If the entity instance is contained in the persistence context,
+     * it is returned from there.
+     * <p>If the entity is found within the persistence context and
+     * the lock mode type is pessimistic and the entity has a version
+     * attribute, the persistence provider must perform optimistic
+     * version checks when obtaining the database lock.  If these checks
+     * fail, the <code>OptimisticLockException</code> will be thrown.
+     * <p>If the lock mode type is pessimistic and the entity instance
+     * is found but cannot be locked:
+     * <ul>
+     * <li> the <code>PessimisticLockException</code> will be thrown
+     *      if the database locking failure causes transaction-level
+     *      rollback
+     * <li> the <code>LockTimeoutException</code> will be thrown if
+     *      the database locking failure causes only statement-level
+     *      rollback
+     * </ul>
+     * <p>If a vendor-specific {@linkplain FindOption option} is not
+     * recognized, it is silently ignored.
+     * <p>Portable applications should not rely on the standard
+     * {@linkplain Timeout timeout option}. Depending on the database
+     * in use and the locking mechanisms used by the provider, this
+     * option may or may not be observed.
+     * @param entityClass  entity class
+     * @param primaryKey  primary key
+     * @param options  standard and vendor-specific options
+     * @return the found entity instance or null if the entity does
+     *         not exist
+     * @throws IllegalArgumentException if there are contradictory
+     *         options, if the first argument does not denote an entity
+     *         type belonging to the persistence unit, or if the second
+     *         argument is not a valid non-null instance of the entity
+     *         primary key type
+     * @throws TransactionRequiredException if there is no transaction
+     *         and a lock mode other than <code>NONE</code> is
+     *         specified or if invoked on an entity manager which has
+     *         not been joined to the current transaction and a lock
+     *         mode other than <code>NONE</code> is specified
+     * @throws OptimisticLockException if the optimistic version check
+     *         fails
+     * @throws PessimisticLockException if pessimistic locking fails
+     *         and the transaction is rolled back
+     * @throws LockTimeoutException if pessimistic locking fails and
+     *         only the statement is rolled back
+     * @throws PersistenceException if an unsupported lock call is made
+     * @since 3.2
+     */
+    public <T> T find(Class<T> entityClass, Object primaryKey,
+                      FindOption... options);
+
+    /**
+     * Find an instance of the root entity of the given {@link EntityGraph}
+     * by primary key, using the specified {@linkplain FindOption options},
+     * and interpreting the {@code EntityGraph} as a load graph.
+     * Search for an entity with the specified type and primary key.
+     * If the given options include a {@link LockModeType}, lock it
+     * with respect to the specified lock type.
+     * If the entity instance is contained in the persistence context,
+     * it is returned from there.
+     * <p> If the entity is found within the persistence context and
+     * the lock mode type is pessimistic and the entity has a version
+     * attribute, the persistence provider must perform optimistic
+     * version checks when obtaining the database lock.  If these checks
+     * fail, the <code>OptimisticLockException</code> will be thrown.
+     * <p>If the lock mode type is pessimistic and the entity instance
+     * is found but cannot be locked:
+     * <ul>
+     * <li> the <code>PessimisticLockException</code> will be thrown
+     *      if the database locking failure causes transaction-level
+     *      rollback
+     * <li> the <code>LockTimeoutException</code> will be thrown if
+     *      the database locking failure causes only statement-level
+     *      rollback
+     * </ul>
+     * <p>If a vendor-specific {@linkplain FindOption option} is not
+     * recognized, it is silently ignored.
+     * <p>Portable applications should not rely on the standard
+     * {@linkplain Timeout timeout option}. Depending on the database
+     * in use and the locking mechanisms used by the provider, this
+     * option may or may not be observed.
+     * @param entityGraph  entity graph interpreted as a load graph
+     * @param primaryKey  primary key
+     * @param options  standard and vendor-specific options
+     * @return the found entity instance or null if the entity does
+     *         not exist
+     * @throws IllegalArgumentException if there are contradictory
+     *         options, if the first argument does not denote an entity
+     *         type belonging to the persistence unit, or if the second
+     *         argument is not a valid non-null instance of the entity
+     *         primary key type
+     * @throws TransactionRequiredException if there is no transaction
+     *         and a lock mode other than <code>NONE</code> is
+     *         specified or if invoked on an entity manager which has
+     *         not been joined to the current transaction and a lock
+     *         mode other than <code>NONE</code> is specified
+     * @throws OptimisticLockException if the optimistic version check
+     *         fails
+     * @throws PessimisticLockException if pessimistic locking fails
+     *         and the transaction is rolled back
+     * @throws LockTimeoutException if pessimistic locking fails and
+     *         only the statement is rolled back
+     * @throws PersistenceException if an unsupported lock call is made
+     * @since 3.2
+     */
+    public <T> T find(EntityGraph<T> entityGraph, Object primaryKey,
+                      FindOption... options);
+
+    /**
      * Get an instance, whose state may be lazily fetched.
      * If the requested instance does not exist in the database,
      * the <code>EntityNotFoundException</code> is thrown when the instance 

--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -642,7 +642,35 @@ public interface EntityManager extends AutoCloseable {
      */
     public LockModeType getLockMode(Object entity);
 
-    /** 
+    /**
+     * Set the cache retrieval mode that is in effect during
+     * query execution. This cache retrieval mode overrides the
+     * cache retrieve mode in use by the entity manager.
+     * @param cacheRetrieveMode cache retrieval mode
+     * @since 3.2
+     */
+    public void setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+    /**
+     * Set the default cache storage mode for this persistence context.
+     * @param cacheStoreMode cache storage mode
+     * @since 3.2
+     */
+    public void setCacheStoreMode(CacheStoreMode cacheStoreMode);
+
+    /**
+     * The cache retrieval mode for this persistence context.
+     * @since 3.2
+     */
+    public CacheRetrieveMode getCacheRetrieveMode();
+
+    /**
+     * The cache storage mode for this persistence context.
+     * @since 3.2
+     */
+    public CacheStoreMode getCacheStoreMode();
+
+    /**
      * Set an entity manager property or hint. 
      * If a vendor-specific property or hint is not recognized, it is
      * silently ignored. 

--- a/api/src/main/java/jakarta/persistence/FindOption.java
+++ b/api/src/main/java/jakarta/persistence/FindOption.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Gavin King      - 3.2
+
+
+package jakarta.persistence;
+
+/**
+ * An option influencing the behavior of {@link EntityManager#find}.
+ * Built-in options control {@linkplain LockModeType locking},
+ * {@linkplain CacheRetrieveMode cache interaction}, and
+ * {@linkplain Timeout timeouts}.
+ *
+ * <p>This interface may be implemented by custom provider-specific
+ * options which extend the options defined by the specification.
+ *
+ * @see LockModeType
+ * @see PessimisticLockScope
+ * @see CacheRetrieveMode
+ * @see CacheStoreMode
+ * @see Timeout
+ *
+ * @see EntityManager#find(Class, Object, FindOption...)
+ * @see EntityManager#find(EntityGraph, Object, FindOption...)
+ *
+ * @since 3.2
+ */
+public interface FindOption {
+}

--- a/api/src/main/java/jakarta/persistence/Graph.java
+++ b/api/src/main/java/jakarta/persistence/Graph.java
@@ -56,6 +56,38 @@ public interface Graph<T> {
     public void addAttributeNode(Attribute<? super T, ?> attribute);
 
     /**
+     * Remove an attribute node from the entity graph.
+     * When this graph is interpreted as a load graph, this operation
+     * suppresses inclusion of an attribute mapped for eager fetching.
+     * The effect of this call may be overridden by subsequent
+     * invocations of {@link #addAttributeNode} or {@link #addSubgraph}.
+     * @param attributeName  name of the attribute
+     * @since 3.2
+     */
+    public void removeAttributeNode(String attributeName);
+
+    /**
+     * Remove an attribute node from the entity graph.
+     * When this graph is interpreted as a load graph, this operation
+     * suppresses inclusion of an attribute mapped for eager fetching.
+     * The effect of this call may be overridden by subsequent
+     * invocations of {@link #addAttributeNode} or {@link #addSubgraph}.
+     * @param attribute  attribute
+     * @since 3.2
+     */
+    public void removeAttributeNode(Attribute<? super T, ?> attribute);
+
+    /**
+     * Remove all attribute nodes of the given attribute types.
+     * When this graph is interpreted as a load graph, this operation
+     * suppresses inclusion of attributes mapped for eager fetching.
+     * The effect of this call may be overridden by subsequent
+     * invocations of {@link #addAttributeNode} or {@link #addSubgraph}.
+     * @since 3.2
+     */
+    public void removeAttributeNodes(Attribute.PersistentAttributeType nodeTypes);
+
+    /**
      * Add one or more attribute nodes to the entity graph.
      *
      * @param attributeName  name of the attribute     

--- a/api/src/main/java/jakarta/persistence/LockModeType.java
+++ b/api/src/main/java/jakarta/persistence/LockModeType.java
@@ -126,7 +126,7 @@ package jakarta.persistence;
  * @since 1.0
  *
  */
-public enum LockModeType implements FindOption {
+public enum LockModeType implements FindOption, RefreshOption {
     /**
      *  Synonymous with <code>OPTIMISTIC</code>.
      *  <code>OPTIMISTIC</code> is to be preferred for new

--- a/api/src/main/java/jakarta/persistence/LockModeType.java
+++ b/api/src/main/java/jakarta/persistence/LockModeType.java
@@ -126,8 +126,7 @@ package jakarta.persistence;
  * @since 1.0
  *
  */
-public enum LockModeType
-{
+public enum LockModeType implements FindOption {
     /**
      *  Synonymous with <code>OPTIMISTIC</code>.
      *  <code>OPTIMISTIC</code> is to be preferred for new

--- a/api/src/main/java/jakarta/persistence/LockOption.java
+++ b/api/src/main/java/jakarta/persistence/LockOption.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Gavin King      - 3.2
+
+
+package jakarta.persistence;
+
+/**
+ * An option influencing the behavior of {@link EntityManager#lock}.
+ * Built-in options control {@linkplain PessimisticLockScope scope},
+ * and {@linkplain Timeout timeouts}.
+ *
+ * <p>This interface may be implemented by custom provider-specific
+ * options which extend the options defined by the specification.
+ *
+ * @see LockModeType
+ * @see PessimisticLockScope
+ * @see Timeout
+ *
+ * @see EntityManager#lock(Object, LockModeType, LockOption...)
+ *
+ * @since 3.2
+ */
+public interface LockOption {
+}

--- a/api/src/main/java/jakarta/persistence/NamedSubgraph.java
+++ b/api/src/main/java/jakarta/persistence/NamedSubgraph.java
@@ -47,7 +47,7 @@ public @interface NamedSubgraph {
      * must be specified when this subgraph is extending a definition
      * on behalf of a subclass.
      */
-    Class type() default void.class;
+    Class<?> type() default void.class;
 
     /** 
      * (Required) The list of the attributes of the class that must

--- a/api/src/main/java/jakarta/persistence/PessimisticLockScope.java
+++ b/api/src/main/java/jakarta/persistence/PessimisticLockScope.java
@@ -27,7 +27,7 @@ package jakarta.persistence;
  *
  * @since 2.0
  */
-public enum PessimisticLockScope implements FindOption, RefreshOption {
+public enum PessimisticLockScope implements FindOption, RefreshOption, LockOption {
 
     /**
      * This value defines the default behavior for pessimistic locking.

--- a/api/src/main/java/jakarta/persistence/PessimisticLockScope.java
+++ b/api/src/main/java/jakarta/persistence/PessimisticLockScope.java
@@ -27,7 +27,7 @@ package jakarta.persistence;
  *
  * @since 2.0
  */
-public enum PessimisticLockScope implements FindOption {
+public enum PessimisticLockScope implements FindOption, RefreshOption {
 
     /**
      * This value defines the default behavior for pessimistic locking.

--- a/api/src/main/java/jakarta/persistence/PessimisticLockScope.java
+++ b/api/src/main/java/jakarta/persistence/PessimisticLockScope.java
@@ -27,7 +27,7 @@ package jakarta.persistence;
  *
  * @since 2.0
  */
-public enum PessimisticLockScope {
+public enum PessimisticLockScope implements FindOption {
 
     /**
      * This value defines the default behavior for pessimistic locking.

--- a/api/src/main/java/jakarta/persistence/Query.java
+++ b/api/src/main/java/jakarta/persistence/Query.java
@@ -547,6 +547,20 @@ public interface Query {
     CacheStoreMode getCacheStoreMode();
 
     /**
+     * Set the query timeout.
+     * @param timeout the timeout, or null to indicate no timeout
+     * @return the same query instance
+     * @since 3.2
+     */
+    Query setTimeout(Integer timeout);
+
+    /**
+     * The query timeout.
+     * @since 3.2
+     */
+    Integer getTimeout();
+
+    /**
      * Return an object of the specified type to allow access to 
      * the provider-specific API.  If the provider's query 
      * implementation does not support the specified class, the 

--- a/api/src/main/java/jakarta/persistence/Query.java
+++ b/api/src/main/java/jakarta/persistence/Query.java
@@ -513,6 +513,40 @@ public interface Query {
     LockModeType getLockMode();
 
     /**
+     * Set the cache retrieval mode that is in effect during
+     * query execution. This cache retrieval mode overrides the
+     * cache retrieve mode in use by the entity manager.
+     * @param cacheRetrieveMode cache retrieval mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    Query setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+    /**
+     * Set the cache storage mode that is in effect during
+     * query execution. This cache storage mode overrides the
+     * cache storage mode in use by the entity manager.
+     * @param cacheStoreMode cache storage mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    Query setCacheStoreMode(CacheStoreMode cacheStoreMode);
+
+    /**
+     * The cache retrieval mode that will be in effect during
+     * query execution.
+     * @since 3.2
+     */
+    CacheRetrieveMode getCacheRetrieveMode();
+
+    /**
+     * The cache storage mode that will be in effect during
+     * query execution.
+     * @since 3.2
+     */
+    CacheStoreMode getCacheStoreMode();
+
+    /**
      * Return an object of the specified type to allow access to 
      * the provider-specific API.  If the provider's query 
      * implementation does not support the specified class, the 

--- a/api/src/main/java/jakarta/persistence/RefreshOption.java
+++ b/api/src/main/java/jakarta/persistence/RefreshOption.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Gavin King      - 3.2
+
+
+package jakarta.persistence;
+
+/**
+ * An option influencing the behavior of {@link EntityManager#refresh}.
+ * Built-in options control {@linkplain LockModeType locking},
+ * {@linkplain CacheStoreMode cache interaction}, and
+ * {@linkplain Timeout timeouts}.
+ *
+ * <p>This interface may be implemented by custom provider-specific
+ * options which extend the options defined by the specification.
+ *
+ * @see LockModeType
+ * @see PessimisticLockScope
+ * @see CacheStoreMode
+ * @see Timeout
+ *
+ * @see EntityManager#refresh(Object, RefreshOption...)
+ *
+ * @since 3.2
+ */
+public interface RefreshOption {
+}

--- a/api/src/main/java/jakarta/persistence/StoredProcedureQuery.java
+++ b/api/src/main/java/jakarta/persistence/StoredProcedureQuery.java
@@ -282,6 +282,14 @@ public interface StoredProcedureQuery extends Query {
     StoredProcedureQuery setCacheStoreMode(CacheStoreMode cacheStoreMode);
 
     /**
+     * Set the query timeout.
+     * @param timeout the timeout, or null to indicate no timeout
+     * @return the same query instance
+     * @since 3.2
+     */
+    StoredProcedureQuery setTimeout(Integer timeout);
+
+    /**
      * Register a positional parameter.
      * All parameters must be registered.
      * @param position  parameter position

--- a/api/src/main/java/jakarta/persistence/StoredProcedureQuery.java
+++ b/api/src/main/java/jakarta/persistence/StoredProcedureQuery.java
@@ -262,6 +262,26 @@ public interface StoredProcedureQuery extends Query {
     StoredProcedureQuery setFlushMode(FlushModeType flushMode);
 
     /**
+     * Set the cache retrieval mode that is in effect during
+     * query execution. This cache retrieval mode overrides the
+     * cache retrieve mode in use by the entity manager.
+     * @param cacheRetrieveMode cache retrieval mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    StoredProcedureQuery setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+    /**
+     * Set the cache storage mode that is in effect during
+     * query execution. This cache storage mode overrides the
+     * cache storage mode in use by the entity manager.
+     * @param cacheStoreMode cache storage mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    StoredProcedureQuery setCacheStoreMode(CacheStoreMode cacheStoreMode);
+
+    /**
      * Register a positional parameter.
      * All parameters must be registered.
      * @param position  parameter position

--- a/api/src/main/java/jakarta/persistence/Timeout.java
+++ b/api/src/main/java/jakarta/persistence/Timeout.java
@@ -22,7 +22,7 @@ package jakarta.persistence;
  *
  * @since 3.2
  */
-public class Timeout implements FindOption {
+public class Timeout implements FindOption, RefreshOption {
     private final int milliseconds;
 
     private Timeout(int milliseconds) {

--- a/api/src/main/java/jakarta/persistence/Timeout.java
+++ b/api/src/main/java/jakarta/persistence/Timeout.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Gavin King      - 3.2
+
+
+package jakarta.persistence;
+
+/**
+ * Specifies a timeout for a database request. This option is
+ * always a hint, and may be ignored by the provider.
+ *
+ * @since 3.2
+ */
+public class Timeout implements FindOption {
+    private final int milliseconds;
+
+    private Timeout(int milliseconds) {
+        this.milliseconds = milliseconds;
+    }
+
+    /**
+     * Specify a timeout in seconds.
+     * (Abbreviation of {@link #seconds(int)}.)
+     */
+    public Timeout s(int seconds) {
+        return new Timeout(seconds*1_000);
+    }
+
+    /**
+     * Specify a timeout in milliseconds.
+     * (Abbreviation of {@link #milliseconds(int)}.)
+     */
+    public Timeout ms(int milliseconds) {
+        return new Timeout(milliseconds);
+    }
+
+    /**
+     * Specify a timeout in seconds.
+     */
+    public Timeout seconds(int seconds) {
+        return new Timeout(seconds*1_000);
+    }
+
+    /**
+     * Specify a timeout in milliseconds.
+     */
+    public Timeout milliseconds(int milliseconds) {
+        return new Timeout(milliseconds);
+    }
+
+    /**
+     * The timeout in milliseconds.
+     */
+    public int milliseconds() {
+        return milliseconds;
+    }
+}

--- a/api/src/main/java/jakarta/persistence/Timeout.java
+++ b/api/src/main/java/jakarta/persistence/Timeout.java
@@ -22,7 +22,7 @@ package jakarta.persistence;
  *
  * @since 3.2
  */
-public class Timeout implements FindOption, RefreshOption {
+public class Timeout implements FindOption, RefreshOption, LockOption {
     private final int milliseconds;
 
     private Timeout(int milliseconds) {

--- a/api/src/main/java/jakarta/persistence/TypedQuery.java
+++ b/api/src/main/java/jakarta/persistence/TypedQuery.java
@@ -316,4 +316,24 @@ public interface TypedQuery<X> extends Query {
       */
      TypedQuery<X> setLockMode(LockModeType lockMode);
 
+    /**
+     * Set the cache retrieval mode that is in effect during
+     * query execution. This cache retrieval mode overrides the
+     * cache retrieve mode in use by the entity manager.
+     * @param cacheRetrieveMode cache retrieval mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    TypedQuery<X> setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+    /**
+     * Set the cache storage mode that is in effect during
+     * query execution. This cache storage mode overrides the
+     * cache storage mode in use by the entity manager.
+     * @param cacheStoreMode cache storage mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    TypedQuery<X> setCacheStoreMode(CacheStoreMode cacheStoreMode);
+
 }

--- a/api/src/main/java/jakarta/persistence/TypedQuery.java
+++ b/api/src/main/java/jakarta/persistence/TypedQuery.java
@@ -336,4 +336,11 @@ public interface TypedQuery<X> extends Query {
      */
     TypedQuery<X> setCacheStoreMode(CacheStoreMode cacheStoreMode);
 
+    /**
+     * Set the query timeout.
+     * @param timeout the timeout, or null to indicate no timeout
+     * @return the same query instance
+     * @since 3.2
+     */
+    TypedQuery<X> setTimeout(Integer timeout);
 }

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -269,6 +269,119 @@ public interface EntityManager extends AutoCloseable {
                       Map<String, Object> properties);
 
     /**
+     * Find an instance of the given entity class by primary key,
+     * using the specified {@linkplain FindOption options}.
+     * Search for an entity with the specified class and primary key.
+     * If the given options include a {@link LockModeType}, lock it
+     * with respect to the specified lock type.
+     * If the entity instance is contained in the persistence context,
+     * it is returned from there.
+     * <p>If the entity is found within the persistence context and
+     * the lock mode type is pessimistic and the entity has a version
+     * attribute, the persistence provider must perform optimistic
+     * version checks when obtaining the database lock.  If these checks
+     * fail, the <code>OptimisticLockException</code> will be thrown.
+     * <p>If the lock mode type is pessimistic and the entity instance
+     * is found but cannot be locked:
+     * <ul>
+     * <li> the <code>PessimisticLockException</code> will be thrown
+     *      if the database locking failure causes transaction-level
+     *      rollback
+     * <li> the <code>LockTimeoutException</code> will be thrown if
+     *      the database locking failure causes only statement-level
+     *      rollback
+     * </ul>
+     * <p>If a vendor-specific {@linkplain FindOption option} is not
+     * recognized, it is silently ignored.
+     * <p>Portable applications should not rely on the standard
+     * {@linkplain Timeout timeout option}. Depending on the database
+     * in use and the locking mechanisms used by the provider, this
+     * option may or may not be observed.
+     * @param entityClass  entity class
+     * @param primaryKey  primary key
+     * @param options  standard and vendor-specific options
+     * @return the found entity instance or null if the entity does
+     *         not exist
+     * @throws IllegalArgumentException if there are contradictory
+     *         options, if the first argument does not denote an entity
+     *         type belonging to the persistence unit, or if the second
+     *         argument is not a valid non-null instance of the entity
+     *         primary key type
+     * @throws TransactionRequiredException if there is no transaction
+     *         and a lock mode other than <code>NONE</code> is
+     *         specified or if invoked on an entity manager which has
+     *         not been joined to the current transaction and a lock
+     *         mode other than <code>NONE</code> is specified
+     * @throws OptimisticLockException if the optimistic version check
+     *         fails
+     * @throws PessimisticLockException if pessimistic locking fails
+     *         and the transaction is rolled back
+     * @throws LockTimeoutException if pessimistic locking fails and
+     *         only the statement is rolled back
+     * @throws PersistenceException if an unsupported lock call is made
+     * @since 3.2
+     */
+    public <T> T find(Class<T> entityClass, Object primaryKey,
+                      FindOption... options);
+
+    /**
+     * Find an instance of the root entity of the given {@link EntityGraph}
+     * by primary key, using the specified {@linkplain FindOption options},
+     * and interpreting the {@code EntityGraph} as a load graph.
+     * Search for an entity with the specified type and primary key.
+     * If the given options include a {@link LockModeType}, lock it
+     * with respect to the specified lock type.
+     * If the entity instance is contained in the persistence context,
+     * it is returned from there.
+     * <p> If the entity is found within the persistence context and
+     * the lock mode type is pessimistic and the entity has a version
+     * attribute, the persistence provider must perform optimistic
+     * version checks when obtaining the database lock.  If these checks
+     * fail, the <code>OptimisticLockException</code> will be thrown.
+     * <p>If the lock mode type is pessimistic and the entity instance
+     * is found but cannot be locked:
+     * <ul>
+     * <li> the <code>PessimisticLockException</code> will be thrown
+     *      if the database locking failure causes transaction-level
+     *      rollback
+     * <li> the <code>LockTimeoutException</code> will be thrown if
+     *      the database locking failure causes only statement-level
+     *      rollback
+     * </ul>
+     * <p>If a vendor-specific {@linkplain FindOption option} is not
+     * recognized, it is silently ignored.
+     * <p>Portable applications should not rely on the standard
+     * {@linkplain Timeout timeout option}. Depending on the database
+     * in use and the locking mechanisms used by the provider, this
+     * option may or may not be observed.
+     * @param entityGraph  entity graph interpreted as a load graph
+     * @param primaryKey  primary key
+     * @param options  standard and vendor-specific options
+     * @return the found entity instance or null if the entity does
+     *         not exist
+     * @throws IllegalArgumentException if there are contradictory
+     *         options, if the first argument does not denote an entity
+     *         type belonging to the persistence unit, or if the second
+     *         argument is not a valid non-null instance of the entity
+     *         primary key type
+     * @throws TransactionRequiredException if there is no transaction
+     *         and a lock mode other than <code>NONE</code> is
+     *         specified or if invoked on an entity manager which has
+     *         not been joined to the current transaction and a lock
+     *         mode other than <code>NONE</code> is specified
+     * @throws OptimisticLockException if the optimistic version check
+     *         fails
+     * @throws PessimisticLockException if pessimistic locking fails
+     *         and the transaction is rolled back
+     * @throws LockTimeoutException if pessimistic locking fails and
+     *         only the statement is rolled back
+     * @throws PersistenceException if an unsupported lock call is made
+     * @since 3.2
+     */
+    public <T> T find(EntityGraph<T> entityGraph, Object primaryKey,
+                      FindOption... options);
+
+    /**
      * Get an instance, whose state may be lazily fetched.
      * If the requested instance does not exist in the database,
      * the <code>EntityNotFoundException</code> is thrown when the instance

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -514,6 +514,54 @@ public interface EntityManager extends AutoCloseable {
                      Map<String, Object> properties);
 
     /**
+     * Lock an entity instance that is contained in the persistence
+     * context with the specified lock mode type, using specified
+     * {@linkplain LockOption options}.
+     * <p>If a pessimistic lock mode type is specified and the entity
+     * contains a version attribute, the persistence provider must
+     * also perform optimistic version checks when obtaining the
+     * database lock.  If these checks fail, the
+     * <code>OptimisticLockException</code> will be thrown.
+     * <p>If the lock mode type is pessimistic and the entity instance
+     * is found but cannot be locked:
+     * <ul>
+     * <li> the <code>PessimisticLockException</code> will be thrown
+     *      if the database locking failure causes transaction-level
+     *      rollback
+     * <li> the <code>LockTimeoutException</code> will be thrown if
+     *      the database locking failure causes only statement-level
+     *      rollback
+     * </ul>
+     * <p>If a vendor-specific {@link LockOption} is not recognized,
+     * it is silently ignored.
+     * <p>Portable applications should not rely on the standard
+     * {@linkplain Timeout timeout option}. Depending on the database
+     * in use and the locking mechanisms used by the provider, the
+     * option may or may not be observed.
+     * @param entity  entity instance
+     * @param lockMode  lock mode
+     * @param options  standard and vendor-specific options
+     * @throws IllegalArgumentException if the instance is not an
+     *         entity or is a detached entity
+     * @throws TransactionRequiredException if there is no
+     *         transaction or if invoked on an entity manager which
+     *         has not been joined to the current transaction
+     * @throws EntityNotFoundException if the entity does not exist
+     *         in the database when pessimistic locking is
+     *         performed
+     * @throws OptimisticLockException if the optimistic version
+     *         check fails
+     * @throws PessimisticLockException if pessimistic locking fails
+     *         and the transaction is rolled back
+     * @throws LockTimeoutException if pessimistic locking fails and
+     *         only the statement is rolled back
+     * @throws PersistenceException if an unsupported lock call is made
+     * @since 3.2
+     */
+    public void lock(Object entity, LockModeType lockMode,
+                     LockOption... options);
+
+    /**
      * Refresh the state of the instance from the database,
      * overwriting changes made to the entity, if any.
      * @param entity  entity instance

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -2932,6 +2932,38 @@ public interface Graph<T> {
     public void addAttributeNode(Attribute<? super T, ?> attribute);
 
     /**
+     * Remove an attribute node from the entity graph.
+     * When this graph is interpreted as a load graph, this operation
+     * suppresses inclusion of an attribute mapped for eager fetching.
+     * The effect of this call may be overridden by subsequent
+     * invocations of {@link #addAttributeNode} or {@link #addSubgraph}.
+     * @param attributeName  name of the attribute
+     * @since 3.2
+     */
+    public void removeAttributeNode(String attributeName);
+
+    /**
+     * Remove an attribute node from the entity graph.
+     * When this graph is interpreted as a load graph, this operation
+     * suppresses inclusion of an attribute mapped for eager fetching.
+     * The effect of this call may be overridden by subsequent
+     * invocations of {@link #addAttributeNode} or {@link #addSubgraph}.
+     * @param attribute  attribute
+     * @since 3.2
+     */
+    public void removeAttributeNode(Attribute<? super T, ?> attribute);
+
+    /**
+     * Remove all attribute nodes of the given attribute types.
+     * When this graph is interpreted as a load graph, this operation
+     * suppresses inclusion of attributes mapped for eager fetching.
+     * The effect of this call may be overridden by subsequent
+     * invocations of {@link #addAttributeNode} or {@link #addSubgraph}.
+     * @since 3.2
+     */
+    public void removeAttributeNodes(Attribute.PersistentAttributeType nodeTypes);
+
+    /**
      * Add one or more attribute nodes to the entity graph.
      *
      * @param attributeName  name of the attribute

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -546,7 +546,7 @@ public interface EntityManager extends AutoCloseable {
      * @since 2.0
      */
     public void refresh(Object entity,
-                            Map<String, Object> properties);
+                        Map<String, Object> properties);
 
     /**
      * Refresh the state of the instance from the database,
@@ -630,6 +630,51 @@ public interface EntityManager extends AutoCloseable {
      */
     public void refresh(Object entity, LockModeType lockMode,
                         Map<String, Object> properties);
+
+    /**
+     * Refresh the state of the given entity instance from the
+     * database, using the specified {@linkplain RefreshOption options},
+     * overwriting changes made to the entity, if any. If the supplied
+     * options include a {@link LockModeType}, lock the given entity with
+     * respect to the specified lock type.
+     * <p>If the lock mode type is pessimistic and the entity instance is
+     * found but cannot be locked:
+     * <ul>
+     * <li> the <code>PessimisticLockException</code> will be thrown if
+     *      the database locking failure causes transaction-level rollback
+     * <li> the <code>LockTimeoutException</code> will be thrown if the
+     *      database locking failure causes only statement-level rollback
+     * </ul>
+     * <p>If a vendor-specific {@link RefreshOption} is not recognized,
+     * it is silently ignored.
+     * <p>Portable applications should not rely on the standard
+     * {@linkplain Timeout timeout option}. Depending on the database in
+     * use and the locking mechanisms used by the provider, the hint may
+     * or may not be observed.
+     * @param entity  entity instance
+     * @param options  standard and vendor-specific options
+     * @throws IllegalArgumentException if the instance is not an entity
+     *         or the entity is not managed
+     * @throws TransactionRequiredException if invoked on a
+     *         container-managed entity manager of type
+     *         <code>PersistenceContextType.TRANSACTION</code> when there
+     *         is no transaction; if invoked on an extended entity manager
+     *         when there is no transaction and a lock mode other than
+     *         <code>NONE</code> has been specified; or if invoked on an
+     *         extended entity manager that has not been joined to the
+     *         current transaction and a lock mode other than
+     *         <code>NONE</code> has been specified
+     * @throws EntityNotFoundException if the entity no longer exists in
+     *         the database
+     * @throws PessimisticLockException if pessimistic locking fails and
+     *         the transaction is rolled back
+     * @throws LockTimeoutException if pessimistic locking fails and only
+     *         the statement is rolled back
+     * @throws PersistenceException if an unsupported lock call is made
+     * @since 3.2
+     */
+    public void refresh(Object entity,
+                        RefreshOption... options);
 
     /**
      * Clear the persistence context, causing all managed

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -676,6 +676,34 @@ public interface EntityManager extends AutoCloseable {
     public LockModeType getLockMode(Object entity);
 
     /**
+     * Set the cache retrieval mode that is in effect during
+     * query execution. This cache retrieval mode overrides the
+     * cache retrieve mode in use by the entity manager.
+     * @param cacheRetrieveMode cache retrieval mode
+     * @since 3.2
+     */
+    public void setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+    /**
+     * Set the default cache storage mode for this persistence context.
+     * @param cacheStoreMode cache storage mode
+     * @since 3.2
+     */
+    public void setCacheStoreMode(CacheStoreMode cacheStoreMode);
+
+    /**
+     * The cache retrieval mode for this persistence context.
+     * @since 3.2
+     */
+    public CacheRetrieveMode getCacheRetrieveMode();
+
+    /**
+     * The cache storage mode for this persistence context.
+     * @since 3.2
+     */
+    public CacheStoreMode getCacheStoreMode();
+
+    /**
      * Set an entity manager property or hint.
      * If a vendor-specific property or hint is not recognized, it is
      * silently ignored.
@@ -1028,7 +1056,7 @@ public interface EntityManager extends AutoCloseable {
      *         the given name
      * @since 2.1
      */
-    public EntityGraph<?> getEntityGraph(String graphName);
+    public  EntityGraph<?> getEntityGraph(String graphName);
 
     /**
      * Return all named EntityGraphs that have been defined for the provided
@@ -4294,7 +4322,10 @@ public interface Query {
      * @throws IllegalArgumentException if the parameter does not
      *         correspond to a parameter of the query
      * @since 2.0
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     Query setParameter(Parameter<Calendar> param, Calendar value,
                        TemporalType temporalType);
 
@@ -4307,7 +4338,10 @@ public interface Query {
      * @throws IllegalArgumentException if the parameter does not
      *         correspond to a parameter of the query
      * @since 2.0
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     Query setParameter(Parameter<Date> param, Date value,
                        TemporalType temporalType);
 
@@ -4331,7 +4365,10 @@ public interface Query {
      * @throws IllegalArgumentException if the parameter name does
      *         not correspond to a parameter of the query or if
      *         the value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     Query setParameter(String name, Calendar value,
                        TemporalType temporalType);
 
@@ -4344,7 +4381,10 @@ public interface Query {
      * @throws IllegalArgumentException if the parameter name does
      *         not correspond to a parameter of the query or if
      *         the value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     Query setParameter(String name, Date value,
                        TemporalType temporalType);
 
@@ -4369,7 +4409,10 @@ public interface Query {
      * @throws IllegalArgumentException if position does not
      *         correspond to a positional parameter of the query or
      *         if the value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     Query setParameter(int position, Calendar value,
                        TemporalType temporalType);
 
@@ -4382,7 +4425,10 @@ public interface Query {
      * @throws IllegalArgumentException if position does not
      *         correspond to a positional parameter of the query or
      *         if the value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     Query setParameter(int position, Date value,
                        TemporalType temporalType);
 
@@ -4554,6 +4600,40 @@ public interface Query {
      * @since 2.0
      */
     LockModeType getLockMode();
+
+    /**
+     * Set the cache retrieval mode that is in effect during
+     * query execution. This cache retrieval mode overrides the
+     * cache retrieve mode in use by the entity manager.
+     * @param cacheRetrieveMode cache retrieval mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    Query setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+    /**
+     * Set the cache storage mode that is in effect during
+     * query execution. This cache storage mode overrides the
+     * cache storage mode in use by the entity manager.
+     * @param cacheStoreMode cache storage mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    Query setCacheStoreMode(CacheStoreMode cacheStoreMode);
+
+    /**
+     * The cache retrieval mode that will be in effect during
+     * query execution.
+     * @since 3.2
+     */
+    CacheRetrieveMode getCacheRetrieveMode();
+
+    /**
+     * The cache storage mode that will be in effect during
+     * query execution.
+     * @since 3.2
+     */
+    CacheStoreMode getCacheStoreMode();
 
     /**
      * Return an object of the specified type to allow access to
@@ -4748,7 +4828,10 @@ public interface TypedQuery<X> extends Query {
      * @return the same query instance
      * @throws IllegalArgumentException if the parameter does not
      *         correspond to a parameter of the query
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     TypedQuery<X> setParameter(Parameter<Calendar> param,
                                Calendar value,
                                TemporalType temporalType);
@@ -4761,7 +4844,10 @@ public interface TypedQuery<X> extends Query {
      * @return the same query instance
      * @throws IllegalArgumentException if the parameter does not
      *         correspond to a parameter of the query
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     TypedQuery<X> setParameter(Parameter<Date> param, Date value,
                                TemporalType temporalType);
 
@@ -4785,7 +4871,10 @@ public interface TypedQuery<X> extends Query {
      * @throws IllegalArgumentException if the parameter name does
      *         not correspond to a parameter of the query or if
      *         the value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     TypedQuery<X> setParameter(String name, Calendar value,
                                TemporalType temporalType);
 
@@ -4798,7 +4887,10 @@ public interface TypedQuery<X> extends Query {
      * @throws IllegalArgumentException if the parameter name does
      *         not correspond to a parameter of the query or if
      *         the value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     TypedQuery<X> setParameter(String name, Date value,
                                TemporalType temporalType);
 
@@ -4823,7 +4915,10 @@ public interface TypedQuery<X> extends Query {
      * @throws IllegalArgumentException if position does not
      *         correspond to a positional parameter of the query
      *         or if the value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     TypedQuery<X> setParameter(int position, Calendar value,
                                TemporalType temporalType);
 
@@ -4836,7 +4931,10 @@ public interface TypedQuery<X> extends Query {
      * @throws IllegalArgumentException if position does not
      *         correspond to a positional parameter of the query
      *         or if the value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     TypedQuery<X> setParameter(int position, Date value,
                                TemporalType temporalType);
 
@@ -4858,6 +4956,26 @@ public interface TypedQuery<X> extends Query {
       *         or a CriteriaQuery query
       */
      TypedQuery<X> setLockMode(LockModeType lockMode);
+
+    /**
+     * Set the cache retrieval mode that is in effect during
+     * query execution. This cache retrieval mode overrides the
+     * cache retrieve mode in use by the entity manager.
+     * @param cacheRetrieveMode cache retrieval mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    TypedQuery<X> setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+    /**
+     * Set the cache storage mode that is in effect during
+     * query execution. This cache storage mode overrides the
+     * cache storage mode in use by the entity manager.
+     * @param cacheStoreMode cache storage mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    TypedQuery<X> setCacheStoreMode(CacheStoreMode cacheStoreMode);
 
 }
 ----
@@ -5156,7 +5274,10 @@ public interface StoredProcedureQuery extends Query {
      * @return the same query instance
      * @throws IllegalArgumentException if the parameter does not
      *         correspond to a parameter of the query
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     StoredProcedureQuery setParameter(Parameter<Calendar> param,
                                       Calendar value,
                                       TemporalType temporalType);
@@ -5169,7 +5290,10 @@ public interface StoredProcedureQuery extends Query {
      * @return the same query instance
      * @throws IllegalArgumentException if the parameter does not
      *         correspond to a parameter of the query
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     StoredProcedureQuery setParameter(Parameter<Date> param,
                                       Date value,
                                       TemporalType temporalType);
@@ -5194,7 +5318,10 @@ public interface StoredProcedureQuery extends Query {
      * @throws IllegalArgumentException if the parameter name does
      *         not correspond to a parameter of the query or if the
      *         value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     StoredProcedureQuery setParameter(String name,
                                       Calendar value,
                                       TemporalType temporalType);
@@ -5208,7 +5335,10 @@ public interface StoredProcedureQuery extends Query {
      * @throws IllegalArgumentException if the parameter name does
      *         not correspond to a parameter of the query or if the
      *         value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     StoredProcedureQuery setParameter(String name,
                                       Date value,
                                       TemporalType temporalType);
@@ -5234,7 +5364,10 @@ public interface StoredProcedureQuery extends Query {
      * @throws IllegalArgumentException if position does not
      *         correspond to a positional parameter of the query or
      *         if the value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     StoredProcedureQuery setParameter(int position,
                                       Calendar value,
                                       TemporalType temporalType);
@@ -5248,7 +5381,10 @@ public interface StoredProcedureQuery extends Query {
      * @throws IllegalArgumentException if position does not
      *         correspond to a positional parameter of the query or
      *         if the value argument is of incorrect type
+     * @deprecated Newly-written code should use the date/time types
+     *             defined in {@link java.time}.
      */
+    @Deprecated(since = "3.2")
     StoredProcedureQuery setParameter(int position,
                                       Date value,
                                       TemporalType temporalType);
@@ -5261,6 +5397,26 @@ public interface StoredProcedureQuery extends Query {
      * @return the same query instance
      */
     StoredProcedureQuery setFlushMode(FlushModeType flushMode);
+
+    /**
+     * Set the cache retrieval mode that is in effect during
+     * query execution. This cache retrieval mode overrides the
+     * cache retrieve mode in use by the entity manager.
+     * @param cacheRetrieveMode cache retrieval mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    StoredProcedureQuery setCacheRetrieveMode(CacheRetrieveMode cacheRetrieveMode);
+
+    /**
+     * Set the cache storage mode that is in effect during
+     * query execution. This cache storage mode overrides the
+     * cache storage mode in use by the entity manager.
+     * @param cacheStoreMode cache storage mode
+     * @return the same query instance
+     * @since 3.2
+     */
+    StoredProcedureQuery setCacheStoreMode(CacheStoreMode cacheStoreMode);
 
     /**
      * Register a positional parameter.


### PR DESCRIPTION
Introduces:

- `FindOption` interface and new overloads of `EM.find()`
- `RefreshOption` interface and new overloads of `EM.refresh()`
- `LockOption` interface and new overloads of `EM.lock()`
- `Graph.removeAttributeNode()`
- `setCacheStoreMode()`/`setCacheRetreiveMode()` on `EntityManager` and `Query`

see #383 and #65. (Also #64.)