### PR TITLE
allow result set mappings to be embedded directly in @NamedNativeQuery

### DIFF
--- a/api/src/main/java/jakarta/persistence/ColumnResult.java
+++ b/api/src/main/java/jakarta/persistence/ColumnResult.java
@@ -21,14 +21,14 @@ import java.lang.annotation.Retention;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Used in conjunction with the {@link SqlResultSetMapping} annotation or
- * {@link ConstructorResult} annotation to map a column of the SELECT
- * list of a SQL query.
+ * Used in conjunction with the {@link SqlResultSetMapping},
+ * {@link NamedNativeQuery}, or {@link ConstructorResult}
+ * annotation to map a column of the SELECT list of a SQL query.
  *
- * <p> The <code>name</code> element references the name of a column in the SELECT list
- *  &#8212; i.e., column alias, if applicable. Scalar result types can be 
- * included in the query result by specifying this annotation in 
- * the metadata.
+ * <p> The <code>name</code> element references the name of a
+ * column in the SELECT list &#8212; i.e., column alias, if
+ * applicable. Scalar result types can be included in the query
+ * result by specifying this annotation in the metadata.
  *
  * <pre>
  *
@@ -54,22 +54,25 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </pre>
  *
  * @see SqlResultSetMapping
+ * @see NamedNativeQuery
+ * @see ConstructorResult
  *
  * @since 1.0
  */
 @Target({}) 
 @Retention(RUNTIME)
-
 public @interface ColumnResult { 
 
-    /** (Required) The name of a column in the SELECT clause of a SQL query */
+    /**
+     * (Required) The name of a column in the SELECT clause of a SQL query
+     */
     String name();
 
     /** 
-     *  (Optional) The Java type to which the column type is to be mapped.
-     *  If the <code>type</code> element is not specified, the default JDBC type 
-     *  mapping for the column will be used.
-     *  @since 2.1
+     * (Optional) The Java type to which the column type is to be mapped.
+     * If the <code>type</code> element is not specified, the default JDBC
+     * type mapping for the column will be used.
+     * @since 2.1
      */
-    Class type() default void.class;
+    Class<?> type() default void.class;
 }

--- a/api/src/main/java/jakarta/persistence/ConstructorResult.java
+++ b/api/src/main/java/jakarta/persistence/ConstructorResult.java
@@ -21,15 +21,16 @@ import java.lang.annotation.Retention;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Used in conjunction with the {@link SqlResultSetMapping} annotation to map the SELECT
- * clause of a SQL query to a constructor.
+ * Used in conjunction with the {@link SqlResultSetMapping} or
+ * {@link NamedNativeQuery} annotation to map the SELECT clause
+ * of a SQL query to a constructor.
  *
  * <p>Applies a constructor for the target class, passing in as arguments
- * values from the specified columns.  All columns corresponding
- * to arguments of the intended constructor must be specified using the
+ * values from the specified columns. All columns corresponding to
+ * arguments of the intended constructor must be specified using the
  * <code>columns</code> element of the <code>ConstructorResult</code>
  * annotation in the same order as that of the argument list of the
- * constructor.  Any entities returned as constructor results will be
+ * constructor. Any entities returned as constructor results will be
  * in either the new or detached state, depending on whether a primary
  * key is retrieved for the constructed object.
  * 
@@ -62,21 +63,23 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </pre>
  *
  * @see SqlResultSetMapping
+ * @see NamedNativeQuery
  * @see ColumnResult
  *
  * @since 2.1
  */
 @Target({}) 
 @Retention(RUNTIME)
-
 public @interface ConstructorResult { 
 
-    /** (Required) The class whose constructor is to be invoked. */
-    Class targetClass();
+    /**
+     * (Required) The class whose constructor is to be invoked.
+     */
+    Class<?> targetClass();
 
     /** 
-     *  (Required) The mapping of columns in the SELECT list to the arguments
-     *  of the intended constructor, in order.
+     * (Required) The mapping of columns in the SELECT list
+     * to the arguments of the intended constructor, in order.
      */
     ColumnResult[] columns();
 }

--- a/api/src/main/java/jakarta/persistence/EntityResult.java
+++ b/api/src/main/java/jakarta/persistence/EntityResult.java
@@ -21,11 +21,12 @@ import java.lang.annotation.Retention;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Used in conjunction with the {@link SqlResultSetMapping} annotation to map the SELECT
- * clause of a SQL query to an entity result.
+ * Used in conjunction with the {@link SqlResultSetMapping} or
+ * {@link NamedNativeQuery} annotation to map the SELECT clause
+ * of a SQL query to an entity result.
  *
  * <p>If this annotation is used, the SQL statement should select 
- * all of the columns that are mapped to the entity object. 
+ * all the columns that are mapped to the entity object.
  * This should include foreign key columns to related entities. 
  * The results obtained when insufficient data is available 
  * are undefined.
@@ -46,6 +47,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </pre>
  *
  * @see SqlResultSetMapping
+ * @see NamedNativeQuery
  *
  * @since 1.0
  */
@@ -53,8 +55,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 public @interface EntityResult { 
 
-    /** The class of the result. */
-    Class entityClass(); 
+    /**
+     * The class of the result.
+     */
+    Class<?> entityClass();
 
     /** 
      * Maps the columns specified in the SELECT list of the 

--- a/api/src/main/java/jakarta/persistence/EntityResult.java
+++ b/api/src/main/java/jakarta/persistence/EntityResult.java
@@ -60,6 +60,12 @@ public @interface EntityResult {
      */
     Class<?> entityClass();
 
+    /**
+     * The lock mode obtained by the SQL query.
+     * @since 3.2
+     */
+    LockModeType lockMode() default LockModeType.OPTIMISTIC;
+
     /** 
      * Maps the columns specified in the SELECT list of the 
      * query to the properties or fields of the entity class. 

--- a/api/src/main/java/jakarta/persistence/FieldResult.java
+++ b/api/src/main/java/jakarta/persistence/FieldResult.java
@@ -51,7 +51,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Target({}) 
 @Retention(RUNTIME)
-
 public @interface FieldResult { 
 
     /** Name of the persistent field or property of the class. */

--- a/api/src/main/java/jakarta/persistence/NamedNativeQuery.java
+++ b/api/src/main/java/jakarta/persistence/NamedNativeQuery.java
@@ -24,10 +24,13 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Specifies a named native SQL query.
+ * Specifies a named native SQL query and, optionally, the mapping of
+ * the result of the native SQL query.
  * Query names are scoped to the persistence unit.
  * The <code>NamedNativeQuery</code> annotation can be applied to an 
  * entity or mapped superclass.
+ *
+ * @see SqlResultSetMapping
  *
  * @since 1.0
  */
@@ -42,15 +45,45 @@ public @interface NamedNativeQuery {
      */
     String name();
 
-    /** The SQL query string. */
+    /**
+     * The SQL query string.
+     */
     String query();
 
-    /** Query properties and hints.  (May include vendor-specific query hints.) */
+    /**
+     * Query properties and hints.
+     * (May include vendor-specific query hints.)
+     */
     QueryHint[] hints() default {};
 
-    /** The class of the result. */
-    Class resultClass() default void.class; 
+    /**
+     * The class of the result.
+     */
+    Class<?> resultClass() default void.class;
 
-    /** The name of a {@link SqlResultSetMapping}, as defined in metadata. */
+    /**
+     * The name of a {@link SqlResultSetMapping}, as defined in metadata.
+     */
     String resultSetMapping() default "";
+
+    /**
+     * Specifies the result set mapping to entities.
+     * May not be used in combination with {@link #resultSetMapping}.
+     * @since 3.2
+     */
+    EntityResult[] entities() default {};
+
+    /**
+     * Specifies the result set mapping to constructors.
+     * May not be used in combination with {@link #resultSetMapping}.
+     * @since 3.2
+     */
+    ConstructorResult[] classes() default {};
+
+    /**
+     * Specifies the result set mapping to scalar values.
+     * May not be used in combination with {@link #resultSetMapping}.
+     * @since 3.2
+     */
+    ColumnResult[] columns() default {};
 }

--- a/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
+++ b/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
@@ -290,27 +290,30 @@ public @interface NamedQueries {
 
 ==== NamedNativeQuery Annotation
 
-The _NamedNativeQuery_ annotation is used to
-specify a native SQL named query.
+The _NamedNativeQuery_ annotation defines a named native SQL query.
 
-The _name_ element is used to refer to the
-query when using the _EntityManager_ methods that create query objects.
+The _name_ element specifies the name used to identify the query when
+calling methods of _EntityManager_ which create query objects.
 
-The _query_ element specifies the native
-query.
+The _query_ element specifies the query itself, written in the native SQL
+dialect of the database.
 
-The _resultClass_ element refers to the class
-of the result; the value of the _resultSetMapping_ element is the name
-of a _SqlResultSetMapping_ specification, as defined in metadata.
+The _resultClass_ element specifies the class of the query result.
 
-The _hints_ elements may be used to specify
-query properties and hints. Hints defined by this specification should
-be observed by the provider when possible. Vendor-specific hints that
-are not recognized by a provider must be ignored.
+The _resultSetMapping_ element specifies the name of a
+_SqlResultSetMapping_ specification defined elsewhere in metadata.
+The named _SqlResultSetMapping_ is used to interpret the result set of
+the native SQL query. Alternatively, the elements _entities_, _classes_,
+and _columns_ may be used to specify a result set mapping. These elements
+may not be used in conjunction with _resultSetMapping_.
 
-The _NamedNativeQuery_ and
-_NamedNativeQueries_ annotations can be applied to an entity or mapped
-superclass.
+The _hints_ element may be used to specify query properties and hints.
+Hints defined by this specification should be observed by the provider
+when possible. Vendor-specific hints which are not recognized by the
+provider must be ignored.
+
+The _NamedNativeQuery_ and _NamedNativeQueries_ annotations can be applied
+to an entity or mapped superclass.
 
 [source,java]
 ----
@@ -323,6 +326,9 @@ public @interface NamedNativeQuery {
     QueryHint[] hints() default {};
     Class resultClass() default void.class;
     String resultSetMapping() default "";
+    EntityResult[] entities() default {};
+    ConstructorResult[] classes() default {};
+    ColumnResult[] columns() default {};
 }
 
 @Target({TYPE})

--- a/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
+++ b/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
@@ -431,9 +431,8 @@ public enum ParameterMode {
 
 ==== Annotations for SQL Result Set Mappings [[a13797]]
 
-The _SqlResultSetMapping_ annotation is used
-to specify the mapping of the result of a native SQL query or stored
-procedure.
+The _SqlResultSetMapping_ annotation is used to specify the mapping of
+the result set of a native SQL query or stored procedure.
 
 [source,java]
 ----
@@ -454,11 +453,12 @@ public @interface SqlResultSetMappings {
 }
 ----
 
-The _name_ element is the name given to the
-result set mapping, and is used to refer to it in the methods of the
-_Query_ and _StoredProcedureQuery_ APIs. The _entities_, _classes_,
-and _columns_ elements are used to specify the mapping to entities,
-constructors, and to scalar values respectively.
+The _name_ element is the name given to the result set mapping, and is
+used to identify it when calling methods of the _EntityManager_ which
+create instances of _Query_ and _StoredProcedureQuery_. The _entities_,
+_classes_, and _columns_ elements are used to specify the mapping of
+result set columns to entities, to constructors, and to scalar values,
+respectively.
 
 [source,java]
 ----
@@ -466,21 +466,23 @@ constructors, and to scalar values respectively.
 @Retention(RUNTIME)
 public @interface EntityResult {
     Class entityClass();
+    LockModeType lockMode() default LockModeType.OPTIMISTIC;
     FieldResult[] fields() default {};
     String discriminatorColumn() default "";
 }
 ----
 
-The _entityClass_ element specifies the class
-of the result.
+The _entityClass_ element specifies the class of the result.
 
-The _fields_ element is used to map the
-columns specified in the SELECT list of the query to the properties or
-fields of the entity class.
+The _lockMode_ element specifies the _LockModeType_ obtained when the
+native SQL query is executed.
 
-The _discriminatorColumn_ element is used to
-specify the column name (or alias) of the column in the SELECT list that
-is used to determine the type of the entity instance.
+The _fields_ element is used to map the columns specified in the SELECT
+list of the query to the properties or fields of the entity class.
+
+The _discriminatorColumn_ element is used to specify the column name
+(or alias) of the column in the SELECT list that is used to determine
+the type of the entity instance.
 
 [source,java]
 ----
@@ -492,12 +494,11 @@ public @interface FieldResult {
 }
 ----
 
-The _name_ element is the name of the
-persistent field or property of the class.
+The _name_ element is the name of the persistent field or property of
+the class.
 
-The _column_ element specifies the name of
-the corresponding column in the SELECT list—i.e., column alias, if
-applicable.
+The _column_ element specifies the name of the corresponding column in
+the SELECT list—i.e., column alias, if applicable.
 
 [source,java]
 ----
@@ -509,12 +510,11 @@ public @interface ConstructorResult {
 }
 ----
 
-The _targetClass_ element specifies the class
-whose constructor is to be invoked.
+The _targetClass_ element specifies the class whose constructor is to
+be invoked.
 
-The _columns_ element specifies the mapping
-of columns in the SELECT list to the arguments of the intended
-constructor.
+The _columns_ element specifies the mapping of columns in the SELECT
+list to the arguments of the intended constructor.
 
 [source,java]
 ----
@@ -526,12 +526,11 @@ public @interface ColumnResult {
 }
 ----
 
-The _name_ element specifies the name of the
-column in the SELECT list.
+The _name_ element specifies the name of the column in the SELECT list.
 
-The _type_ element specifies the Java type to
-which the column type is to be mapped. If the _type_ element is not
-specified, the default JDBC type mapping for the column will be used.
+The _type_ element specifies the Java type to which the column type is
+to be mapped. If the _type_ element is not specified, the default JDBC
+type mapping for the column will be used.
 
 === References to EntityManager and EntityManagerFactory
 


### PR DESCRIPTION
and add lockMode to `@EntityResult`.

see #471, #472