### PR TITLE
eliminate dependence on JDBC from runWithConnection()

### DIFF
--- a/api/src/main/java/jakarta/persistence/ConnectionConsumer.java
+++ b/api/src/main/java/jakarta/persistence/ConnectionConsumer.java
@@ -16,11 +16,11 @@
 
 package jakarta.persistence;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
 /**
- * An executable action which makes use of a {@linkplain Connection JDBC connection}.
+ * An executable action which makes use of a native database connection.
+ * The connection is usually a JDBC connection.
+ *
+ * @param <C> the connection type, usually {@code java.sql.Connection}
  *
  * @see ConnectionFunction
  * @see EntityManager#runWithConnection(ConnectionConsumer)
@@ -28,13 +28,14 @@ import java.sql.SQLException;
  * @since 3.2
  */
 @FunctionalInterface
-public interface ConnectionConsumer {
+public interface ConnectionConsumer<C> {
 	/**
 	 * Execute the action using the given connection.
 	 *
 	 * @param connection the connection to use
 	 *
-	 * @throws SQLException if a problem occurs calling JDBC
+	 * @throws Exception if a problem occurs calling the connection,
+	 *                   usually a {@code java.sql.SQLException}
 	 */
-	void accept(Connection connection) throws SQLException;
+	void accept(C connection) throws Exception;
 }

--- a/api/src/main/java/jakarta/persistence/ConnectionFunction.java
+++ b/api/src/main/java/jakarta/persistence/ConnectionFunction.java
@@ -16,12 +16,11 @@
 
 package jakarta.persistence;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
 /**
- * A function which makes use of a {@linkplain Connection JDBC connection}
- * to compute a result.
+ * A function which makes use of a native database connection to compute
+ * a result. The connection is usually a JDBC connection.
+ *
+ * @param <C> the connection type, usually {@code java.sql.Connection}
  *
  * @see ConnectionConsumer
  * @see EntityManager#callWithConnection(ConnectionFunction)
@@ -29,7 +28,7 @@ import java.sql.SQLException;
  * @since 3.2
  */
 @FunctionalInterface
-public interface ConnectionFunction<T> {
+public interface ConnectionFunction<C,T> {
 	/**
 	 * Compute a result using the given connection.
 	 *
@@ -37,7 +36,8 @@ public interface ConnectionFunction<T> {
 	 *
 	 * @return the result
 	 * 
-	 * @throws SQLException if a problem occurs calling JDBC
+	 * @throws Exception if a problem occurs calling the connection,
+	 *                   usually a {@code java.sql.SQLException}
 	 */
-	T apply(Connection connection) throws SQLException;
+	T apply(C connection) throws Exception;
 }

--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -1130,35 +1130,41 @@ public interface EntityManager extends AutoCloseable {
     public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass);
 
     /**
-     * Execute the given action using the {@link java.sql.Connection} underlying
-     * this {@code EntityManager}. If this {@code EntityManager} is associated
-     * with a transaction, the action is executed in the context of the transaction.
-     * The given action should close any JDBC resources it creates, but should not
-     * close the connection itself, nor commit or roll back the transaction. If the
-     * given action throws an exception, the persistence provider must mark the
+     * Execute the given action using the database connection underlying this
+     * {@code EntityManager}. Usually, the connection is a JDBC connection, but a
+     * provider might support some other native connection type, and is not required
+     * to support {@code java.sql.Connection}. If this {@code EntityManager} is
+     * associated with a transaction, the action is executed in the context of the
+     * transaction. The given action should close any resources it creates, but should
+     * not close the connection itself, nor commit or roll back the transaction. If
+     * the given action throws an exception, the persistence provider must mark the
      * transaction for rollback.
      * @param action the action
-     * @throws PersistenceException wrapping the {@link java.sql.SQLException}
-     *         thrown by {@link ConnectionConsumer#accept}, if any
+     * @param <C> the connection type, usually {@code java.sql.Connection}
+     * @throws PersistenceException wrapping the checked {@link Exception} thrown by
+     *         {@link ConnectionConsumer#accept}, if any
      * @since 3.2
      */
-    public void runWithConnection(ConnectionConsumer action);
+    public <C> void runWithConnection(ConnectionConsumer<C> action);
 
     /**
-     * Call the given function and return its result using the
-     * {@link java.sql.Connection} underlying this {@code EntityManager}. If this
+     * Call the given function and return its result using the database connection
+     * underlying this {@code EntityManager}. Usually, the connection is a JDBC
+     * connection, but a provider might support some other native connection type,
+     * and is not required to support {@code java.sql.Connection}. If this
      * {@code EntityManager} is associated with a transaction, the function is
      * executed in the context of the transaction. The given function should close
-     * any JDBC resources it creates, but should not close the connection itself,
-     * nor commit or roll back the transaction. If the given action throws an
-     * exception, the persistence provider must mark the transaction for rollback.
+     * any resources it creates, but should not close the connection itself, nor
+     * commit or roll back the transaction. If the given action throws an exception,
+     * the persistence provider must mark the transaction for rollback.
      * @param function the function
+     * @param <C> the connection type, usually {@code java.sql.Connection}
      * @param <T> the type of result returned by the function
      * @return the value returned by {@link ConnectionFunction#apply}.
-     * @throws PersistenceException wrapping the {@link java.sql.SQLException}
-     *         thrown by {@link ConnectionFunction#apply}, if any
+     * @throws PersistenceException wrapping the checked {@link Exception} thrown by
+     *         {@link ConnectionFunction#apply}, if any
      * @since 3.2
      */
-    public <T> T callWithConnection(ConnectionFunction<T> function);
+    public <C,T> T callWithConnection(ConnectionFunction<C,T> function);
 
 }

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -1162,36 +1162,42 @@ public interface EntityManager extends AutoCloseable {
     public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass);
 
     /**
-     * Execute the given action using the {@link java.sql.Connection} underlying
-     * this {@code EntityManager}. If this {@code EntityManager} is associated
-     * with a transaction, the action is executed in the context of the transaction.
-     * The given action should close any JDBC resources it creates, but should not
-     * close the connection itself, nor commit or roll back the transaction. If the
-     * given action throws an exception, the persistence provider must mark the
+     * Execute the given action using the database connection underlying this
+     * {@code EntityManager}. Usually, the connection is a JDBC connection, but a
+     * provider might support some other native connection type, and is not required
+     * to support {@code java.sql.Connection}. If this {@code EntityManager} is
+     * associated with a transaction, the action is executed in the context of the
+     * transaction. The given action should close any resources it creates, but should
+     * not close the connection itself, nor commit or roll back the transaction. If
+     * the given action throws an exception, the persistence provider must mark the
      * transaction for rollback.
      * @param action the action
-     * @throws PersistenceException wrapping the {@link java.sql.SQLException}
-     *         thrown by {@link ConnectionConsumer#accept}, if any
+     * @param <C> the connection type, usually {@code java.sql.Connection}
+     * @throws PersistenceException wrapping the checked {@link Exception} thrown by
+     *         {@link ConnectionConsumer#accept}, if any
      * @since 3.2
      */
-    public void runWithConnection(ConnectionConsumer action);
+    public <C> void runWithConnection(ConnectionConsumer<C> action);
 
     /**
-     * Call the given function and return its result using the
-     * {@link java.sql.Connection} underlying this {@code EntityManager}. If this
+     * Call the given function and return its result using the database connection
+     * underlying this {@code EntityManager}. Usually, the connection is a JDBC
+     * connection, but a provider might support some other native connection type,
+     * and is not required to support {@code java.sql.Connection}. If this
      * {@code EntityManager} is associated with a transaction, the function is
      * executed in the context of the transaction. The given function should close
-     * any JDBC resources it creates, but should not close the connection itself,
-     * nor commit or roll back the transaction. If the given action throws an
-     * exception, the persistence provider must mark the transaction for rollback.
+     * any resources it creates, but should not close the connection itself, nor
+     * commit or roll back the transaction. If the given action throws an exception,
+     * the persistence provider must mark the transaction for rollback.
      * @param function the function
+     * @param <C> the connection type, usually {@code java.sql.Connection}
      * @param <T> the type of result returned by the function
      * @return the value returned by {@link ConnectionFunction#apply}.
-     * @throws PersistenceException wrapping the {@link java.sql.SQLException}
-     *         thrown by {@link ConnectionFunction#apply}, if any
+     * @throws PersistenceException wrapping the checked {@link Exception} thrown by
+     *         {@link ConnectionFunction#apply}, if any
      * @since 3.2
      */
-    public <T> T callWithConnection(ConnectionFunction<T> function);
+    public <C,T> T callWithConnection(ConnectionFunction<C,T> function);
 
 }
 ----


### PR DESCRIPTION
makes the connection type generic

see #483