### PR TITLE
nail down holes in the semantics of @Converter/@Convert

### DIFF
--- a/spec/src/main/asciidoc/ch02-entities.adoc
+++ b/spec/src/main/asciidoc/ch02-entities.adoc
@@ -1114,7 +1114,7 @@ public class MedicalHistory {
 }
 ----
 
-=== Basic Type
+=== Basic Type [[a486]]
 
 A basic type is any Java primitive type, wrapper of the primitive types, java.lang.String,
 java.math.BigInteger, java.math.BigDecimal, java.util.Date, java.util.Calendar,

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -3901,23 +3901,29 @@ and _description_ attributes) are also fetched.
 
 === Type Conversion of Basic Attributes [[a2999]]
 
-The attribute conversion facility
-allows the developer to specify methods to convert between the entity
-attribute representation and the database representation for attributes
-of basic types. Converters can be used to convert basic attributes
-defined by entity classes, mapped superclasses, or embeddable
-classes.footnote:[We plan to provide a
-facility for more complex attribute conversions in a future release of
-this specification.]
+The attribute conversion facility allows the developer to define custom
+attribute converters. A _converter_ is a class whose methods convert
+between:
 
-An attribute converter must implement the
-_jakarta.persistence.AttributeConverter_ interface. A converter
-implementation class must be annotated with the _Converter_ annotation
-or defined in the XML descriptor as a converter. If the value of the
-_autoApply_ element of the _Converter_ annotation is _true_, the
-converter will be applied to all attributes of the target type,
-including to basic attribute values that are contained within other,
-more complex attribute types. See <<a13903>>.
+- the _target type_ of the converter, an arbitrary Java type which may be
+  used as the type of a persistent field or property, and
+- a basic type (see <<a486>>) used as an intermediate step in mapping to
+  the database representation.
+
+A converter can be used to convert attributes defined by entity classes,
+mapped superclasses, or embeddable classes.footnote:[We plan to provide a
+facility for more complex attribute conversions in a future release of
+this specification.] A converted attribute is considered a basic attribute,
+since, with the aid of the converter, its values can be represented as
+instances of a basic type.
+
+Every attribute converter class must implement the interface
+_jakarta.persistence.AttributeConverter_ and must be annotated with the
+_Converter_ annotation or declared as a converter in the XML descriptor.
+If the value of the _autoApply_ element of the _Converter_ annotation is
+_true_, the converter is automatically applied to all attributes of the
+target type, including to basic attribute values that are contained within
+other, more complex attribute types. See <<a13903>>.
 
 [source,java]
 ----

--- a/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
+++ b/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
@@ -660,12 +660,14 @@ public @interface PersistenceUnits {
 }
 ----
 
-=== Annotations for Type Converter Classes [[a13903]]
+=== Annotations for Attribute Converter Classes [[a13903]]
 
-The _Converter_ annotation specifies that the
-annotated class is a converter and defines its scope. A converter class
-must be annotated with the _Converter_ annotation or defined in the XML
-descriptor as a converter.
+The _Converter_ annotation declares that the annotated class is a converter
+and specifies whether the converter is applied automatically. Every converter
+class must implement _AttributeConverter_  and must be annotated with the
+_Converter_ annotation or declared as a converter in the XML descriptor. The
+target type for a converter is determined by the actual type argument of the
+first type parameter of _AttributeConverter_.
 
 [source,java]
 ----
@@ -676,30 +678,29 @@ public @interface Converter {
 }
 ----
 
-If the _autoApply_ element is specified as
-_true_, the persistence provider must automatically apply the converter
-to all mapped attributes of the specified target type for all entities
-in the persistence unit except for attributes for which conversion is
-overridden by means of the _Convert_ annotation (or XML equivalent). The
-_Convert_ annotation is described in <<a14398>>.
+If the _autoApply_ element is specified as _true_, the persistence provider
+must automatically apply the converter to every mapped attribute of the
+specified target type belonging to any entity in the persistence unit, except
+for attributes for which conversion is overridden by means of the _Convert_
+annotation (or XML equivalent). The _Convert_ annotation is described in
+<<a14398>>. The _Convert_ annotation may be used to override or disable
+auto-apply conversion on a per-attribute basis.
 
-In determining whether a converter is
-applicable to an attribute, the provider must treat primitive types and
-wrapper types as equivalent.
+In determining whether a converter applies to an attribute, the provider
+must treat primitive types and wrapper types as equivalent.
 
-Note that Id attributes, version attributes,
-relationship attributes, and attributes explicitly annotated as
-_Enumerated_ or _Temporal_ (or designated as such via XML) will not be
-converted.
+A converter never applies to id attributes, version attributes,
+relationship attributes, or to attributes explicitly annotated as
+_Enumerated_ or _Temporal_ (or designated as such via XML).
 
-If _autoApply_ is _false_, only those
-attributes of the target type for which the _Convert_ annotation (or
-corresponding XML element) has been specified will be converted.
+A converter never applies to any attribute annotated
+_@Convert(disableConversion=true)_ or to an attribute for which the
+_Convert_ annotation explicitly specifies a different converter.
 
-Note that if _autoApply_ is _true_, the
-_Convert_ annotation may be used to override or disable auto-apply
-conversion on a per-attribute basis.
+If _autoApply_ is _false_, the converter applies only to attributes of the
+target type for which conversion is explicitly enabled via the _Convert_
+annotation (or corresponding XML element).
 
-If there is more than one converter defined
-for the same target type, the _Convert_ annotation should be used to
-explicitly specify which converter to use.
+If there is more than one converter defined for the same target type,
+the _Convert_ annotation must be used to explicitly specify which
+converter applies.

--- a/spec/src/main/asciidoc/ch11-metadata-for-or-mapping.adoc
+++ b/spec/src/main/asciidoc/ch11-metadata-for-or-mapping.adoc
@@ -995,17 +995,24 @@ public BigDecimal getCost() {
 
 ==== Convert Annotation [[a14398]]
 
-The _Convert_ annotation is applied directly
-to an attribute of an entity, mapped superclass, or embeddable class to
-specify conversion of a Basic attribute or to override the use of a
-converter that has been specified as _autoApply=true_. When persistent
-properties are used, the _Convert_ annotation is applied to the getter
-method. It is not necessary to use the _Basic_ annotation or
-corresponding XML element to specify the basic type
+The _Convert_ annotation specifies how the values of a field or property
+are converted to a basic type, enabling a converter which was defined
+_autoApply=false_, overriding the use of a converter which was defined
+_autoApply=true_ (see <<a13903>>), or overriding the use of a converter
+specified by a field or property of an embedded type or inherited mapped
+superclass.
 
-The _Convert_ annotation may be applied to an
-entity that extends a mapped superclass to specify or override the
-conversion mapping for an inherited basic attribute.
+When persistent properties are used, the _Convert_ annotation is applied
+to the getter method.
+
+It is not necessary to use the _Basic_ annotation or corresponding XML
+element to specify the converted basic type. Nor is it usually necessary
+to explicitly specify the converter class, except to disambiguate cases
+where multiple converters would otherwise apply.
+
+The _Convert_ annotation may be applied to an entity that extends a
+mapped superclass to specify or override the conversion mapping for
+an inherited basic attribute.
 
 [source,java]
 ----
@@ -1019,8 +1026,8 @@ public @interface Convert {
 }
 ----
 
-<<a14410>> lists the annotation elements that may be specified
-for the _Convert_ annotation.
+<<a14410>> lists the annotation elements that may be specified for the
+_Convert_ annotation.
 
 .Convert Annotation Elements
 [#a14410,options="header"]
@@ -1035,7 +1042,7 @@ for the _Convert_ annotation.
 |String
 |attributeName
 |(Optional) The name of the attribute to
-convert. Must be specified unless the Convert annotation is applied to
+convert. Must be specified unless the _Convert_ annotation is applied to
 an attribute of basic type or to an element collection of basic type.
 Must not be specified otherwise.
 |The basic
@@ -1044,62 +1051,76 @@ is applied
 
 |boolean
 |disableConversion
-|(Optional) Whether conversion of the
-attribute is to be disabled.
+|(Optional) Whether conversion of the attribute is to be disabled.
 |false
 |===
 
-The _converter_ element is used to specify
-the converter that is to be applied. If an autoApply converter is
-applicable to the given field or property, the converter specified by
-the _converter_ element will be applied instead.
+The _converter_ element specifies the converter that is applied. Even if
+an automatically-applied converter would otherwise be applicable to the
+annotated field or property, the converter specified by the _converter_
+element must be applied instead.
 
-The _disableConversion_ element specifies
-that any applicable autoApply converter must not be applied.
+The _disableConversion_ element specifies that any automatically-applied
+converter that would otherwise be applicable to the given field or property
+must not be applied.
 
-The behavior is undefined if neither the
-_converter_ element nor the _disableConversion_ element has been
-specified.
+If neither the _converter_ element nor the _disableConversion_ element is
+specified, and there is exactly one converter for the type of the annotated
+field or property, that converter is applied, even if it is not an
+automatically-applied converter.
 
-The _Convert_ annotation should not be used
-to specify conversion of the following: Id attributes (including the
-attributes of embedded ids and derived identities), version attributes,
-relationship attributes, and attributes explicitly annotated (or
-designated via XML) as _Enumerated_ or _Temporal_. Applications that
-specify such conversions will not be portable.
+If multiple converters are applicable to the annotated field or property,
+and the _converter_ element is not specified, the behavior is undefined.
 
-The _Convert_ annotation may be applied to a
-basic attribute or to an element collection of basic type (in which case
-the converter is applied to the elements of the collection). In these
-cases, the _attributeName_ element must not be specified.
+The _Convert_ annotation should not be used to specify conversion of
+id attributes, (including the attributes of embedded ids and derived
+identities), of version attributes, of relationship attributes, or of
+attributes explicitly annotated (or designated via XML) as _Enumerated_
+or _Temporal_. Applications that depend on such conversions are not
+portable.
 
-The _Convert_ annotation may be applied to an
-embedded attribute or to a map collection attribute whose key or value
-is of embeddable type (in which case the converter is applied to the
-specified attribute of the embeddable instances contained in the
-collection). In these cases, the _attributeName_ element must be
-specified.
+The _Convert_ annotation may be applied to:
 
-To override conversion mappings at multiple
-levels of embedding, a dot (_"."_) notation form must be used in the
-_attributeName_ element to indicate an attribute within an embedded
-attribute. The value of each identifier used with the dot notation is
-the name of the respective embedded field or property.
+- a basic attribute, or
+- a collection attribute (that is, an _ElementCollection_) of any
+  type other than _Map_, in which case the converter is applied to
+  the elements of the collection.
 
-When the _Convert_ annotation is applied to a
-map containing instances of embeddable classes, the _attributeName_
-element must be specified, and _"key."_ or _"value."_ must be used to
-prefix the name of the attribute that is to be converted in order to
-specify it as part of the map key or map value.
+In these cases, the _attributeName_ element must not be specified.
 
-When the _Convert_ annotation is applied to a
-map to specify conversion of a map key of basic type, _"key"_ must be
-used as the value of the _attributeName_ element to specify that it is
-the map key that is to be converted.
+Alternatively, the _Convert_ annotation may be applied to:
 
-The _Convert_ annotation may be applied to an
-entity class that extends a mapped superclass to specify or override a
-conversion mapping for an inherited basic or embedded attribute.
+- an embedded attribute,
+- a collection attribute (that is, an _ElementCollection_) whose
+  element type is an embeddable type, in which case the converter
+  is applied to the specified attribute of the embeddable instances
+  contained in the collection,
+- a map collection attribute (that is, an _ElementCollection_ of
+  type _Map_), in which case the converter is applied to the keys or
+  values of the map, or to the specified attribute of the embeddable
+  instances contained in the map, or
+- an entity class which extends a mapped superclass, to enable or
+  override conversion of an inherited basic or embedded attribute.
+
+In these cases, the _attributeName_ element must be specified.
+
+To override conversion mappings at multiple levels of embedding, a dot
+(_"."_) notation form must be used in the _attributeName_ element to
+indicate an attribute within an embedded attribute. The value of each
+identifier used with the dot notation is the name of the respective
+embedded field or property.
+
+The dot notation may also be used with map entries:
+
+- When the _Convert_ annotation is applied to a map to specify conversion
+  of a map key or value of basic type, _"key"_ or _"value"_, respectively,
+  must be used as the value of the _attributeName_ element to specify that
+  it is the map key or value that is converted.
+
+- When the _Convert_ annotation is applied to a map whose key or value type
+  is an embeddable type, the _attributeName_ element must be specified, and
+  _"key."_ or _"value."_ (respectively) must be used to prefix the name of
+  the attribute of the key or value type that is converted.
 
 *Example 1:* Convert a basic attribute
 


### PR DESCRIPTION
- Actually define what a converter target type is!
- Clarify what happens with a plain `@Convert` with no `converter` and no `disableConversion` ... it was vaguely implied by the javadoc that this applies a non-auto-apply converter, but this was contradicted by a line in the spec saying that the behavior is undefined.
- Make it clear that the "target type" may be any arbitrary Java type, but that the converted type must be a basic type.
- Properly define all cases involving element collections.

see #509