### PR TITLE
factory-level access to named queries and named entity graphs

### DIFF
--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -1085,6 +1085,22 @@ public interface EntityManager extends AutoCloseable {
     <T> TypedQuery<T> createNamedQuery(String name, Class<T> resultClass);
 
     /**
+     * Create an instance of {@link TypedQuery} for executing a
+     * named query written in the Jakarta Persistence query
+     * language or in native SQL.
+     * @param reference a reference to the query defined in metadata
+     * @return the new query instance
+     * @throws IllegalArgumentException if a query has not been
+     *         defined, or if the query string is found to be
+     *         invalid, or if the query result is found to not be
+     *         assignable to the specified type
+     * @see EntityManagerFactory#getNamedQueries(Class)
+     * @see NamedQuery
+     * @see NamedNativeQuery
+     */
+    <T> TypedQuery<T> createQuery(TypedQueryReference<T> reference);
+
+    /**
      * Create an instance of {@link Query} for executing a native
      * SQL statement, e.g., for update or delete.
      *

--- a/api/src/main/java/jakarta/persistence/EntityManagerFactory.java
+++ b/api/src/main/java/jakarta/persistence/EntityManagerFactory.java
@@ -346,6 +346,28 @@ public interface EntityManagerFactory extends AutoCloseable {
     <T> void addNamedEntityGraph(String graphName, EntityGraph<T> entityGraph);
 
     /**
+     * A map keyed by {@linkplain NamedQuery#name query name}, containing
+     * {@linkplain TypedQueryReference references} to every named query whose
+     * result type is assignable to the given Java type.
+     * @param resultType any Java type, including {@code Object.class}
+     *                   meaning all queries
+     * @return a map keyed by query name
+     * @param <R> the specified upper bound on the query result types
+     */
+    <R> Map<String, TypedQueryReference<R>> getNamedQueries(Class<R> resultType);
+
+    /**
+     * A map keyed by {@linkplain NamedEntityGraph#name graph name}, containing
+     * every named {@linkplain EntityGraph entity graph} whose entity type is
+     * assignable to the given Java type.
+     * @param entityType any Java type, including {@code Object.class}
+     *                   meaning all entity graphs
+     * @return a map keyed by graph name
+     * @param <E> the specified upper bound on the entity graph types
+     */
+    <E> Map<String, EntityGraph<? extends E>> getNamedEntityGraphs(Class<E> entityType);
+
+    /**
      * Create a new application-managed {@link EntityManager} with an active
      * transaction, and execute the given function, passing the {@code EntityManager}
      * to the function.

--- a/api/src/main/java/jakarta/persistence/NamedEntityGraph.java
+++ b/api/src/main/java/jakarta/persistence/NamedEntityGraph.java
@@ -23,7 +23,15 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Used to specify the path and boundaries for a find operation or query.
+ * Defines a named {@linkplain EntityGraph entity graph}. This annotation
+ * must be applied to the root entity of the graph, and specifies the
+ * limits of the graph of associated attributes and entities fetched when
+ * an operation which retrieves an instance or instances of the root entity
+ * is executed.
+ *
+ * <p> A reference to a named entity graph may be obtained by calling
+ * {@link EntityManager#getEntityGraph(String)}, and may be passed to
+ * {@link EntityManager#find(EntityGraph, Object, FindOption...)}.
  *
  * @since 2.1
  */
@@ -33,8 +41,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface NamedEntityGraph {
 
     /**
-     * (Optional) The name of the entity graph.
-     * Defaults to the entity name of the root entity.
+     * (Optional) The name used to identify the entity graph in calls to
+     * {@link EntityManager#getEntityGraph(String)}. If no name is explicitly
+     * specified, the name defaults to the entity name of the annotated root
+     * entity. Entity graph names must be unique within the persistence unit.
      */
     String name() default "";
 

--- a/api/src/main/java/jakarta/persistence/NamedQuery.java
+++ b/api/src/main/java/jakarta/persistence/NamedQuery.java
@@ -11,9 +11,10 @@
  */
 
 // Contributors:
+//     Gavin King       - 3.2
 //     Petros Splinakis - 2.2
-//     Linda DeMichiel - 2.1
-//     Linda DeMichiel - 2.0
+//     Linda DeMichiel  - 2.1
+//     Linda DeMichiel  - 2.0
 
 package jakarta.persistence;
 
@@ -25,30 +26,30 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /** 
- * Declares a static, named query in the Jakarta Persistence query
- * language. Query names are scoped to the persistence unit. The
- * {@code NamedQuery} annotation can be applied to an entity or
- * mapped superclass.
+ * Declares a named query written in the Jakarta Persistence
+ * query language. Query names are scoped to the persistence unit.
+ * A named query may be executed by calling
+ * {@link EntityManager#createNamedQuery(String, Class)}.
  *
  * <p> The following is an example of the definition of a named
- * query in the Jakarta Persistence query language:
- *
+ * query written in the Jakarta Persistence query language:
  * {@snippet :
  * @NamedQuery(
  *     name = "findAllCustomersWithName",
  *     query = "SELECT c FROM Customer c WHERE c.name LIKE :custName")
  * }
  *
- * <p> The following is an example of the use of a named query:
- *
+ * <p> The named query may be executed like this:
  * {@snippet :
- * @PersistenceContext
- * public EntityManager em;
+ * @PersistenceContext EntityManager em;
  * ...
- * customers = em.createNamedQuery("findAllCustomersWithName")
+ * List<Customer> customers = em.createNamedQuery("findAllCustomersWithName", Customer.class)
  *               .setParameter("custName", "Smith")
  *               .getResultList();
  * }
+ *
+ * The {@code NamedQuery} annotation can be applied to an entity
+ * class or mapped superclass.
  *
  * @since 1.0
  */
@@ -58,8 +59,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface NamedQuery {
 
     /** 
-     * (Required) The name used to refer to the query with the
-     * {@link EntityManager} methods that create query objects.
+     * (Required) The name used to identify the query in calls to
+     * {@link EntityManager#createNamedQuery}.
      */
     String name();
 
@@ -69,7 +70,17 @@ public @interface NamedQuery {
      */
     String query();
 
-    /** 
+    /**
+     * (Optional) The class of each query result. The result class
+     * may be overridden by explicitly passing a class object to
+     * {@link EntityManager#createNamedQuery(String, Class)}. If
+     * the result class of a named query is not specified, the
+     * persistence implementation is entitled to default the
+     * result class to {@code Object} or {@code Object[]}.
+     */
+    Class<?> resultClass() default void.class;
+
+    /**
      * (Optional) The lock mode type to use in query execution.
      * If a {@code lockMode} other than {@link LockModeType#NONE}
      * is specified, the query must be executed in a transaction

--- a/api/src/main/java/jakarta/persistence/TypedQueryReference.java
+++ b/api/src/main/java/jakarta/persistence/TypedQueryReference.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Gavin King      - 3.2
+
+package jakarta.persistence;
+
+import java.util.Map;
+
+/**
+ * A reference to a named query declared via the {@link NamedQuery}
+ * or {@link NamedNativeQuery} annotations.
+ *
+ * @param <R> an upper bound on the result type of the query
+ *
+ * @see EntityManager#createQuery(TypedQueryReference)
+ */
+public interface TypedQueryReference<R> {
+    /**
+     * The name of the query.
+     */
+    String getName();
+
+    /**
+     * The result type of the query.
+     */
+    Class<? extends R> getResultType();
+
+    /**
+     * A map keyed by hint name of all hints specified via
+     * {@link NamedQuery#hints} or {@link NamedNativeQuery#hints}.
+     */
+    Map<String,Object> getHints();
+}

--- a/spec/src/main/asciidoc/ch06-criteria-api.adoc
+++ b/spec/src/main/asciidoc/ch06-criteria-api.adoc
@@ -76,17 +76,21 @@ unit, a corresponding metamodel class is produced as follows:
 `X_` in package `p` is created.footnote:[We expect that the
 option of different packages will be provided in a future release of
 this specification.]
+
 * The name of the metamodel class is derived from the name of the
 managed class by appending "`_`" to the name of the managed class.
+
 * The metamodel class `X_` must be annotated with the
 `jakarta.persistence.StaticMetamodel` annotationfootnote:[If the class
 was generated, the `javax.annotation.processing.Generated` or `jakarta.annotation.Generated`
 annotation should be used to annotate the class. The use of any other annotations on static
 metamodel classes is undefined.].
+
 * If the managed class `X` extends another class `S`, where `S` is the
 most derived managed class (i.e., entity or mapped superclass) extended
 by `X`, then the metamodel class `X_` must extend the metamodel
 class `S_` created for `S`.
+
 * The metamodel class must contain a field declaration as follows:
 +
 [source,java]
@@ -108,6 +112,7 @@ where the field name `Y` is obtained by transforming each lowercase
 character in the attribute name `y` to uppercase, and inserting an
 underscore if the character following the transformed character
 is uppercase.
+
 * For every persistent non-collection-valued
 attribute `y` declared by class `X`, where the type of `y` is `Y`, the
 metamodel class must contain a declaration as follows:
@@ -117,6 +122,7 @@ metamodel class must contain a declaration as follows:
 public static volatile SingularAttribute<X, Y> y;
 ----
 +
+
 * For every persistent collection-valued
 attribute `z` declared by class `X`, where the element type of `z` is
 `Z`, the metamodel class must contain a declaration as follows:
@@ -149,6 +155,7 @@ public static volatile MapAttribute<X, K, Z> z;
 ----
 +
 where `K` is the type of the key of the map in class `X`
+
 * For every named query, named entity graph, or SQL result set
 mapping with name `"n"` declared by annotations of the class `X`,
 the metamodel class must contain a declaration as follows:
@@ -166,6 +173,26 @@ following the transformed character is uppercase, and then
 replacing each character which is not a legal Java identifier
 character with an underscore.
 
+* For every named query with name `"n"` and query result class
+`R` declared by annotations of the class `X`, the metamodel class
+must contain a declaration as follows:
++
+[source,java]
+----
+public static volatile TypedQueryReference<R> _n_;
+----
++
+
+* For every named entity graph with name `"n"` declared by
+annotations of the class `X`, the metamodel class must contain
+a declaration as follows:
++
+[source,java]
+----
+public static volatile EntityGraph<X> _n;
+----
++
+
 Import statements must be included for the
 needed `jakarta.persistence.metamodel` types as appropriate (e.g.,
 `jakarta.persistence.metamodel.SingularAttribute`,
@@ -173,7 +200,7 @@ needed `jakarta.persistence.metamodel` types as appropriate (e.g.,
 `jakarta.persistence.metamodel.SetAttribute`,
 `jakarta.persistence.metamodel.ListAttribute`,
 `jakarta.persistence.metamodel.MapAttribute`) and all classes `X`, `Y`,
-`Z`, and `K`.
+`Z`, `R`, and `K`.
 
 [NOTE]
 ====

--- a/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
+++ b/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
@@ -239,28 +239,35 @@ public @interface NamedSubgraph {
 
 ==== NamedQuery Annotation [[a13711]]
 
-The `NamedQuery` annotation is used to
-specify a named query in the Jakarta Persistence query language.
+The `NamedQuery` annotation declared a named query written in the Jakarta
+Persistence query language.
 
-The `name` element is used to refer to the
-query when using the `EntityManager` methods that create query objects.
+The `name` element assigns a name to the query, which is used to identify
+the query in calls to `EntityManager.createNamedQuery()`.
 
-The `query` element must specify a query
-string in the Jakarta Persistence query language.
+The `query` element must specify a query string itself, written in the
+Jakarta Persistence query language.
 
-The `lockMode` element specifies a lock mode
-for the results returned by the query. If a lock mode other than `NONE`
-is specified, the query must be executed within a transaction and the
-persistence context joined to the transaction.
+The `resultClass` element specifies the Java class of each query result.
+The query result class may be overridden by explicitly passing a `Class`
+object to `EntityManager.createNamedQuery(String, Class)`. If the
+`resultClass` element of a `NamedQuery` annotation is not specified, the
+persistence implementation is entitled to default the result class to
+`Object` or `Object[]`.
 
-The `hints` elements may be used to specify
-query properties and hints. Properties defined by this specification
-must be observed by the provider; hints defined by this specification
-should be observed by the provider when possible. Vendor-specific hints
-that are not recognized by a provider must be ignored.
+The `lockMode` element specifies a lock mode for the entity instances in
+results returned by the query. If a lock mode other than `NONE` is
+specified, the query may only be executed within a persistence context
+with an associated active transaction.
 
-The `NamedQuery` and `NamedQueries`
-annotations can be applied to an entity or mapped superclass.
+The `hints` elements may be used to specify query properties and hints.
+Properties defined by this specification must be observed by the provider;
+hints defined by this specification should be observed by the provider
+when possible. Vendor-specific hints that are not recognized by a provider
+must be ignored.
+
+The `NamedQuery` and `NamedQueries` annotations can be applied to an entity
+or mapped superclass.
 
 [source,java]
 ----
@@ -270,6 +277,7 @@ annotations can be applied to an entity or mapped superclass.
 public @interface NamedQuery {
     String name();
     String query();
+    Class<?> resultClass() default void.class;
     LockModeType lockMode() default NONE;
     QueryHint[] hints() default {};
 }
@@ -292,20 +300,26 @@ public @interface NamedQueries {
 
 The `NamedNativeQuery` annotation defines a named native SQL query.
 
-The `name` element specifies the name used to identify the query when
-calling methods of `EntityManager` which create query objects.
+The `name` element assigns a name to the query, which is used to identify
+the query in calls to `EntityManager.createNamedQuery()`.
 
-The `query` element specifies the query itself, written in the native SQL
-dialect of the database.
+The `query` element must specify the query string itself, written in the
+native SQL dialect of the database.
 
-The `resultClass` element specifies the class of the query result.
+The `resultClass` element specifies the class of each query result. If a
+result set mapping is specified, the specified result class must agree
+with the type inferred from the result set mapping. If a `resultClass` is
+not explicitly specified, then it is inferred from the result set mapping,
+if any, or defaults to `Object` or `Object[]`. The query result class may
+be overridden by explicitly passing a `Class` object to
+`EntityManager.createNamedQuery(String, Class)`.
 
-The `resultSetMapping` element specifies the name of a
-`SqlResultSetMapping` specification defined elsewhere in metadata.
-The named `SqlResultSetMapping` is used to interpret the result set of
-the native SQL query. Alternatively, the elements `entities`, `classes`,
-and `columns` may be used to specify a result set mapping. These elements
-may not be used in conjunction with `resultSetMapping`.
+The `resultSetMapping` element specifies the name of a `SqlResultSetMapping`
+specification defined elsewhere in metadata. The named `SqlResultSetMapping`
+is used to interpret the result set of the native SQL query. Alternatively,
+the elements `entities`, `classes`, and `columns` may be used to specify a
+result set mapping. These elements may not be used in conjunction with
+`resultSetMapping`.
 
 The `hints` element may be used to specify query properties and hints.
 Hints defined by this specification should be observed by the provider

--- a/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
+++ b/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
@@ -112,18 +112,16 @@ public @interface PostLoad {}
 
 ==== NamedEntityGraph and NamedEntityGraphs Annotations
 
-The `NamedEntityGraph` annotation is used to
-define a named entity graph. The entity graph may be retrieved by name
-using the `EntityManagerFactory` interface. The entity graph may be used
-to specify the path and boundaries for `find` operations or queries.
+The `NamedEntityGraph` annotation defines a named entity graph. The
+annotation must be applied to the root entity of the graph, and specifies
+the limits of the graph of associated attributes and entities fetched when
+an operation which retrieves an instance or instances of the root entity is
+executed.
 
-The `NamedEntityGraph` annotation must be
-applied to the entity class that forms the root of the corresponding
-graph of entities.
-
-The `name` element is used to refer to the
-entity graph. It defaults to the entity name of the root entity to which
-the annotation is applied. Entity graph names must be unique within the
+The `name` element assigns a name to the entity graph, and is used to
+identify the entity graph in calls to `EntityManager.getEntityGraph()`.
+If no name is explicitly specified, the name defaults to the entity name
+of the annotated root entity. Entity graph names must be unique within the
 persistence unit.
 
 The `attributeNodes` element lists attributes


### PR DESCRIPTION
Introduces `NamedQueryReference` and:

```java
interface EntityManagerFactory {
    ...

    <R> Map<String, NamedQueryReference<R>> getNamedQueries(Class<R> resultType);
    <E> Map<String, EntityGraph<? extends E>> getNamedEntityGraphs(Class<E> entityType);
}
```
```java
interface EntityManager {
    ...

    <R> TypedQuery<R> createNamedQuery(NamedQueryReference<R> reference);
}
```

as proposed in #505.

Also adds typesafe references to named queries and named entity graphs to the canonical metamodel, enabling typesafe code like:

```java
@NamedEntityGraph(name = "withAuthors", ... )
@Entity
class Book { ... }

Book book = em.find(Book_._withAuthors, bookId);
```

and:

```java
@NamedQuery(name = "byTitle", ... )
@Entity
class Book { ... }

List<Book> books = 
        em.createNamedQuery(Book_._byTitle_)
             .setParameter(1, title)
             .getResultList();
```