### PR TITLE
deprecate CriteriaQuery.multiselect and add overloads of array(), tuple()

### DIFF
--- a/api/src/main/java/jakarta/persistence/criteria/CriteriaBuilder.java
+++ b/api/src/main/java/jakarta/persistence/criteria/CriteriaBuilder.java
@@ -105,13 +105,33 @@ public interface CriteriaBuilder {
     CompoundSelection<Tuple> tuple(Selection<?>... selections);
 
     /**
+     * Create a tuple-valued selection item.
+     * @param selections  list of selection items
+     * @return tuple-valued compound selection
+     * @throws IllegalArgumentException if an argument is a
+     *         tuple- or array-valued selection item
+     * @since 3.2
+     */
+    CompoundSelection<Tuple> tuple(List<Selection<?>> selections);
+
+    /**
      * Create an array-valued selection item.
      * @param selections  selection items
      * @return array-valued compound selection
-     * @throws IllegalArgumentException if an argument is a 
+     * @throws IllegalArgumentException if an argument is a
      *         tuple- or array-valued selection item
      */
     CompoundSelection<Object[]> array(Selection<?>... selections);
+
+    /**
+     * Create an array-valued selection item.
+     * @param selections  list of selection items
+     * @return array-valued compound selection
+     * @throws IllegalArgumentException if an argument is a
+     *         tuple- or array-valued selection item
+     * @since 3.2
+     */
+    CompoundSelection<Object[]> array(List<Selection<?>> selections);
 
 
     //ordering:

--- a/api/src/main/java/jakarta/persistence/criteria/CriteriaQuery.java
+++ b/api/src/main/java/jakarta/persistence/criteria/CriteriaQuery.java
@@ -118,7 +118,12 @@ public interface CriteriaQuery<T> extends AbstractQuery<T> {
      * @throws IllegalArgumentException if a selection item is
      *         not valid or if more than one selection item has
      *         the same assigned alias
+     *
+     * @deprecated Since this method is not typesafe, the use of
+     * {@link CriteriaBuilder#array} or {@link CriteriaBuilder#tuple}
+     * with {@link #select} is strongly preferred.
      */
+    @Deprecated(since = "3.2")
     CriteriaQuery<T> multiselect(Selection<?>... selections);
 
 
@@ -177,7 +182,12 @@ public interface CriteriaQuery<T> extends AbstractQuery<T> {
      * @throws IllegalArgumentException if a selection item is
      *         not valid or if more than one selection item has
      *         the same assigned alias
+     *
+     * @deprecated Since this method is not typesafe, the use of
+     * {@link CriteriaBuilder#array} or {@link CriteriaBuilder#tuple}
+     * with {@link #select} is strongly preferred.
      */
+    @Deprecated(since = "3.2")
     CriteriaQuery<T> multiselect(List<Selection<?>> selectionList);
 
     /**

--- a/spec/src/main/asciidoc/appendixes.adoc
+++ b/spec/src/main/asciidoc/appendixes.adoc
@@ -41,7 +41,7 @@ Added constants for managed types, named queries, named graphs and named result 
 
 Added _LocalDateTime_ and _Instant_ to supported _Version_ types
 
-Added _where()_, _having()_, _and()_, and _or()_ overloads accepting _List<Predicate>_ to _CriteriaQuery_ and _CriteriaBuilder_
+Added _where()_, _having()_, _and()_, _or()_, _array()_, _tuple()_ overloads accepting _List_ to _CriteriaQuery_ and _CriteriaBuilder_
 
 Added _equalTo()_ and _notEqualTo()_ to _Expression_
 

--- a/spec/src/main/asciidoc/ch06-criteria-api.adoc
+++ b/spec/src/main/asciidoc/ch06-criteria-api.adoc
@@ -340,6 +340,15 @@ public interface CriteriaBuilder {
     CompoundSelection<Tuple> tuple(Selection<?>... selections);
 
     /**
+     * Create a tuple-valued selection item.
+     * @param selections  list of selection items
+     * @return tuple-valued compound selection
+     * @throws IllegalArgumentException if an argument is a
+     *         tuple- or array-valued selection item
+     */
+    CompoundSelection<Tuple> tuple(List<Selection<?>> selections);
+
+    /**
      * Create an array-valued selection item.
      * @param selections  selection items
      * @return array-valued compound selection
@@ -347,6 +356,15 @@ public interface CriteriaBuilder {
      *         tuple- or array-valued selection item
      */
     CompoundSelection<Object[]> array(Selection<?>... selections);
+
+    /**
+     * Create an array-valued selection item.
+     * @param selections  list of selection items
+     * @return array-valued compound selection
+     * @throws IllegalArgumentException if an argument is a
+     *         tuple- or array-valued selection item
+     */
+    CompoundSelection<Object[]> array(List<Selection<?>> selections);
 
 
     //ordering:


### PR DESCRIPTION
There are two commits here:

1. adds overloads of `array()`, `tuple()` accepting `List` to `CriteriaBuilder`, and
2. deprecates `multiselect()` because it's not typesafe.