### PR TITLE
examples should not have their own section

### DIFF
--- a/spec/src/main/asciidoc/ch02-entities.adoc
+++ b/spec/src/main/asciidoc/ch02-entities.adoc
@@ -193,7 +193,7 @@ Object/relational mapping metadata may be specified to customize the
 object/relational mapping and the loading and storing of the entity state
 and relationships. See <<a13915>>.
 
-==== Example
+For example:
 
 [source,java]
 ----
@@ -640,6 +640,8 @@ entity.
   are _not_ derived from any parent entity.
 
 ===== Examples of Derived Identities
+
+The following examples illustrate the rules specified above.
 
 *Example 1:*
 

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -1324,7 +1324,7 @@ observed by the provider if possible, a hint may or may not always be
 observed. A portable application must not depend on the observance of a
 hint.
 
-==== Example of Use of EntityManager API
+For example:
 
 [source,java]
 ----
@@ -2614,7 +2614,7 @@ callback methods are invoked before or after the cascading of the
 lifecycle events to related entities. Applications should not depend on
 this ordering.
 
-==== Example
+For example:
 
 [source,java]
 ----
@@ -2716,7 +2716,7 @@ then invokes the next callback method, if any.
 The XML descriptor may be used to override
 the lifecycle callback method invocation order specified in annotations.
 
-==== Example
+For example:
 
 There are several entity classes and listeners for animals:
 
@@ -5852,7 +5852,7 @@ Runtime exceptions thrown by the methods of
 the `Tuple`, `TupleElement`, and `Parameter` interfaces do not cause
 the current transaction to be marked for rollback.
 
-===== Example
+For example:
 
 [source,java]
 ----

--- a/spec/src/main/asciidoc/ch04-query-language.adoc
+++ b/spec/src/main/asciidoc/ch04-query-language.adoc
@@ -235,7 +235,7 @@ FROM Order AS o JOIN o.lineItems AS l
 WHERE l.shipped = FALSE
 ----
 
-.Abstract Persistence Schema of Several Entities with Defined in the Same Persistence Unit.
+.Abstract persistence schema of several entities defined in the same persistence unit.
 [[a4724]]
 image::images/Per-6.svg[Image]
 
@@ -2579,8 +2579,6 @@ The invocation of aggregate database
 functions, including user defined functions, is supported by means of
 the FUNCTION operator. See <<a5311>>.
 
-===== Examples
-
 The following query returns the average order quantity:
 
 [source,sql]
@@ -2941,13 +2939,9 @@ enums are required to be supported.
 Comparisons over instances of embeddable
 class or map entry types are not supported.
 
-=== Examples
-
 The following examples illustrate the syntax
 and semantics of the Jakarta Persistence query language. These examples are
 based on the example presented in <<a4713>>.
-
-==== Simple Queries
 
 Find all orders:
 
@@ -2973,8 +2967,6 @@ Find all states for which there are orders:
 SELECT DISTINCT o.shippingAddress.state
 FROM Order o
 ----
-
-==== Queries with Relationships
 
 Find all orders that have line items:
 

--- a/spec/src/main/asciidoc/ch07-entitymanagers-and-persistence-contexts.adoc
+++ b/spec/src/main/asciidoc/ch07-entitymanagers-and-persistence-contexts.adoc
@@ -656,8 +656,6 @@ public interface EntityTransaction {
 }
 ----
 
-==== Example
-
 The following example illustrates the
 creation of an entity manager factory in a Java SE environment, and its
 use in creating and using a resource-local entity manager.
@@ -965,9 +963,8 @@ component propagating either a persistence context of type
 `SynchronizationType.SYNCHRONIZED` into it.
 ====
 
-==== Examples
-
-===== Container-managed Transaction-scoped Persistence Context
+The following example shows a container-managed, transaction-scoped
+persistence context:
 
 [source,java]
 ----
@@ -997,7 +994,7 @@ public class ShoppingCartImpl implements ShoppingCart {
 }
 ----
 
-===== Container-managed Extended Persistence Context
+This example shows a container-managed extended persistence context:
 
 [source,java]
 ----
@@ -1093,9 +1090,8 @@ The `EntityManager.isOpen` method indicates
 whether the entity manager is open. The `isOpen` method returns true
 until the entity manager has been closed.
 
-==== Examples
-
-===== Application-managed Persistence Context used in Stateless Session Bean
+This example shows an application-managed persistence context used in
+a stateless session bean:
 
 [source,java]
 ----
@@ -1138,7 +1134,8 @@ public class ShoppingCartImpl implements ShoppingCart {
 }
 ----
 
-===== Application-managed Persistence Context used in Stateless Session Bean
+This examples shows an application-managed persistence context used in
+a stateless session bean:
 
 [source,java]
 ----
@@ -1196,7 +1193,8 @@ public class ShoppingCartImpl implements ShoppingCart {
 }
 ----
 
-===== Application-managed Persistence Context used in Stateful Session Bean
+This example shows an application-managed persistence context used in
+a stateful session bean:
 
 [source,java]
 ----
@@ -1245,7 +1243,8 @@ public class ShoppingCartImpl implements ShoppingCart {
 }
 ----
 
-===== Application-managed Persistence Context with Resource Transaction
+Finally, this example shows an application-managed persistence context
+used with a resource transaction:
 
 [source,java]
 ----

--- a/spec/src/main/asciidoc/ch08-entity-packaging.adoc
+++ b/spec/src/main/asciidoc/ch08-entity-packaging.adoc
@@ -595,8 +595,6 @@ Vendors should define properties in vendor-specific namespaces, (e.g
 is reserved for use by this specification, and must not be used to
 define vendor-specific properties.
 
-===== Examples
-
 The following are sample contents of a `persistence.xml` file.
 
 *Example 1:*

--- a/spec/src/main/asciidoc/ch11-metadata-for-or-mapping.adoc
+++ b/spec/src/main/asciidoc/ch11-metadata-for-or-mapping.adoc
@@ -5898,7 +5898,7 @@ the constraint.
 
 === Examples of the Application of Annotations for Object/Relational Mapping
 
-==== Examples of Simple Mappings
+This example shows some simple mappings:
 
 [source,java]
 ----
@@ -6076,7 +6076,7 @@ public class DeliveryService {
 }
 ----
 
-==== A More Complex Example
+Next, we have a more complex example:
 
 [source,java]
 ----


### PR DESCRIPTION
Generally, a code example should not be declared in its own section, but should rather occur directly in the section of the spec defining the stuff it's an example of. Here, I've cleaned up most of the instances which violated this principle.