### PR TITLE
allow id() and version() in scalar_expression rule

### DIFF
--- a/spec/src/main/asciidoc/ch04-query-language.adoc
+++ b/spec/src/main/asciidoc/ch04-query-language.adoc
@@ -3038,14 +3038,16 @@ The syntax of the ORDER BY clause is:
 
 ----
 orderby_clause ::= ORDER BY orderby_item {, orderby_item}*
-orderby_item ::=
-    {state_field_path_expression | general_identification_variable | result_variable | scalar_expression}
-        [ASC | DESC]
-        [NULLS {FIRST | LAST}]
+orderby_item ::= orderby_expression [ASC | DESC] [NULLS {FIRST | LAST}]
+orderby_expression ::=
+    state_field_path_expression |
+    general_identification_variable |
+    result_variable |
+    scalar_expression
 ----
 
-The ORDER BY clause specifies a list of items. Each `orderby_item` must be
-one of the following:
+The ORDER BY clause specifies a list of items. Each `orderby_expression`
+must be one of the following:
 
 1. A `state_field_path_expression` evaluating to an orderable state field
    of an entity or embeddable class abstract schema type designated in the
@@ -3336,10 +3338,12 @@ groupby_clause ::= GROUP BY groupby_item {, groupby_item}*
 groupby_item ::= single_valued_path_expression | identification_variable
 having_clause ::= HAVING conditional_expression
 orderby_clause ::= ORDER BY orderby_item {, orderby_item}*
-orderby_item ::=
-    {state_field_path_expression | general_identification_variable | result_variable | scalar_expression}
-        [ASC | DESC]
-        [NULLS {FIRST | LAST}]
+orderby_item ::= orderby_expression [ASC | DESC] [NULLS {FIRST | LAST}]
+orderby_expression ::=
+    state_field_path_expression |
+    general_identification_variable |
+    result_variable |
+    scalar_expression
 subquery ::= simple_select_clause subquery_from_clause [where_clause]
     [groupby_clause] [having_clause]
 subquery_from_clause ::=

--- a/spec/src/main/asciidoc/ch04-query-language.adoc
+++ b/spec/src/main/asciidoc/ch04-query-language.adoc
@@ -1921,14 +1921,15 @@ involving aggregate operators must not be used in the WHERE clause.] and
 HAVING clauses.
 
 ----
-scalar_expression::=
+scalar_expression ::=
     arithmetic_expression |
     string_expression |
     enum_expression |
     datetime_expression |
     boolean_expression |
     case_expression |
-    entity_type_expression
+    entity_type_expression |
+    entity_id_or_version_function
 ----
 
 ==== Literals
@@ -3371,7 +3372,8 @@ scalar_expression ::=
     datetime_expression |
     boolean_expression |
     case_expression |
-    entity_type_expression
+    entity_type_expression |
+    entity_id_or_version_function
 conditional_expression ::= conditional_term | conditional_expression OR conditional_term
 conditional_term ::= conditional_factor | conditional_term AND conditional_factor
 conditional_factor ::= [NOT] conditional_primary


### PR DESCRIPTION
Eeeeek, apologies @lukasj I messed this up. Of course I *totally* intended for `entity_id_or_version_function` to be a `scalar_expression` and I could have sworn I wrote that down!
