### PR TITLE
Two minor things for 3.2

### DIFF
--- a/api/src/main/java/jakarta/persistence/Column.java
+++ b/api/src/main/java/jakarta/persistence/Column.java
@@ -166,6 +166,8 @@ public @interface Column {
      * should not be stored in a {@code time} column, or that the
      * maximum number of digits supported by the database and JDBC
      * driver should be stored in a {@code timestamp} column.
+     *
+     * @since 3.2
      */
     int secondPrecision() default -1;
 

--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -555,6 +555,7 @@ public interface EntityManager extends AutoCloseable {
      *         an entity, or if it is neither persistent nor detached
      * @throws EntityNotFoundException if the entity state cannot be
      *         accessed
+     * @since 3.2
      */
     <T> T getReference(T entity);
 

--- a/api/src/main/java/jakarta/persistence/EntityManagerFactory.java
+++ b/api/src/main/java/jakarta/persistence/EntityManagerFactory.java
@@ -353,6 +353,8 @@ public interface EntityManagerFactory extends AutoCloseable {
      *                   meaning all queries
      * @return a map keyed by query name
      * @param <R> the specified upper bound on the query result types
+     *
+     * @since 3.2
      */
     <R> Map<String, TypedQueryReference<R>> getNamedQueries(Class<R> resultType);
 
@@ -364,6 +366,8 @@ public interface EntityManagerFactory extends AutoCloseable {
      *                   meaning all entity graphs
      * @return a map keyed by graph name
      * @param <E> the specified upper bound on the entity graph types
+     *
+     * @since 3.2
      */
     <E> Map<String, EntityGraph<? extends E>> getNamedEntityGraphs(Class<E> entityType);
 
@@ -389,6 +393,8 @@ public interface EntityManagerFactory extends AutoCloseable {
      * control to the client.
      *
      * @param work a function to be executed in the scope of the transaction
+     *
+     * @since 3.2
      */
     void runInTransaction(Consumer<EntityManager> work);
     /**
@@ -415,6 +421,8 @@ public interface EntityManagerFactory extends AutoCloseable {
      *
      * @param work a function to be called in the scope of the transaction
      * @return the value returned by the given function
+     *
+     * @since 3.2
      */
     <R> R callInTransaction(Function<EntityManager, R> work);
 }

--- a/api/src/main/java/jakarta/persistence/Query.java
+++ b/api/src/main/java/jakarta/persistence/Query.java
@@ -140,6 +140,8 @@ public interface Query {
      * @throws PersistenceException if the query execution exceeds
      *         the query timeout value set and the transaction
      *         is rolled back
+     *
+     * @since 3.2
      */
     Object getSingleResultOrNull();
 

--- a/api/src/main/java/jakarta/persistence/TypedQuery.java
+++ b/api/src/main/java/jakarta/persistence/TypedQuery.java
@@ -138,6 +138,8 @@ public interface TypedQuery<X> extends Query {
      * @throws PersistenceException if the query execution exceeds
      *         the query timeout value set and the transaction
      *         is rolled back
+     *
+     * @since 3.2
      */
     X getSingleResultOrNull();
 

--- a/api/src/main/java/jakarta/persistence/TypedQueryReference.java
+++ b/api/src/main/java/jakarta/persistence/TypedQueryReference.java
@@ -24,6 +24,8 @@ import java.util.Map;
  * @param <R> an upper bound on the result type of the query
  *
  * @see EntityManager#createQuery(TypedQueryReference)
+ *
+ * @since 3.2
  */
 public interface TypedQueryReference<R> {
     /**

--- a/spec/src/main/asciidoc/appA-revision-history.adoc
+++ b/spec/src/main/asciidoc/appA-revision-history.adoc
@@ -83,7 +83,7 @@ Added `comment` and `check` members to `@Table` and `@Column` annotations, along
 
 Added `secondPrecision` to `@Column` annotation and clarified semantics of `@Column` members
 
-Added factory-level access to named queries and named entity graphs
+Added factory-level access to named queries and named entity graphs, along with `TypedQueryReference`
 
 Added integration points for dependency injection
 


### PR DESCRIPTION
1. add missing `@since` annotations
2. mention `TypedQueryReference` in changelog