### PR TITLE
errata: @EntityResult.lockMode should default to NONE

### DIFF
--- a/api/src/main/java/jakarta/persistence/EntityResult.java
+++ b/api/src/main/java/jakarta/persistence/EntityResult.java
@@ -68,7 +68,7 @@ public @interface EntityResult {
      * The lock mode obtained by the SQL query.
      * @since 3.2
      */
-    LockModeType lockMode() default LockModeType.OPTIMISTIC;
+    LockModeType lockMode() default LockModeType.NONE;
 
     /** 
      * Maps the columns specified in the SELECT list of the 

--- a/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
+++ b/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
@@ -480,7 +480,7 @@ respectively.
 @Retention(RUNTIME)
 public @interface EntityResult {
     Class entityClass();
-    LockModeType lockMode() default LockModeType.OPTIMISTIC;
+    LockModeType lockMode() default LockModeType.NONE;
     FieldResult[] fields() default {};
     String discriminatorColumn() default "";
 }

--- a/spec/src/main/asciidoc/ch12-xml-or-mapping-descriptor.adoc
+++ b/spec/src/main/asciidoc/ch12-xml-or-mapping-descriptor.adoc
@@ -1920,7 +1920,7 @@ object/relational mapping schema for use with the Persistence API.
         @Target({}) @Retention(RUNTIME)
         public @interface EntityResult {
           Class<?> entityClass();
-          LockModeType lockMode() default LockModeType.OPTIMISTIC;
+          LockModeType lockMode() default LockModeType.NONE;
           FieldResult[] fields() default {};
           String discriminatorColumn() default "";
         }


### PR DESCRIPTION
Since `OPTIMISTIC` has a slightly-weird definition in JPA.

@lukasj I messed up, is it too late to fix this?