### PR TITLE
errata: two minor fixes to javadoc

### DIFF
--- a/api/src/main/java/jakarta/persistence/CheckConstraint.java
+++ b/api/src/main/java/jakarta/persistence/CheckConstraint.java
@@ -47,8 +47,6 @@ public @interface CheckConstraint {
     /**
      * (Optional) A SQL fragment appended to the generated DDL
      * which creates this constraint.
-     *
-     * @since 3.2
      */
     String options() default "";
 }

--- a/api/src/main/java/jakarta/persistence/SchemaValidationException.java
+++ b/api/src/main/java/jakarta/persistence/SchemaValidationException.java
@@ -16,7 +16,7 @@
 package jakarta.persistence;
 
 /**
- * Thrown when {@link SchemaManager#validate() schema validation} fails.
+ * Thrown when {@linkplain SchemaManager#validate() schema validation} fails.
  *
  * @see SchemaManager#validate()
  *


### PR DESCRIPTION
- remove superfluous @since annotation
- change @link -> @linkplain