### PR TITLE
Polish ConstraintMode

### DIFF
--- a/api/src/main/java/jakarta/persistence/ConstraintMode.java
+++ b/api/src/main/java/jakarta/persistence/ConstraintMode.java
@@ -23,10 +23,10 @@ package jakarta.persistence;
 public enum ConstraintMode {
 
     /** Apply the constraint. */
-	CONSTRAINT,
+    CONSTRAINT,
 
     /** Do not apply the constraint. */
-	NO_CONSTRAINT,
+    NO_CONSTRAINT,
 
     /** Use the provider-defined default behavior. */
     PROVIDER_DEFAULT


### PR DESCRIPTION
Replace tab with spaces for consistency.

Although the codebase is mixing usage of tab and spaces, but it's not good to do that in single source file, it's better to unify across the entire codebase, I like tab personally.