### PR TITLE
add a way to exclude a column from schema validation

### DIFF
--- a/api/src/main/java/jakarta/persistence/Column.java
+++ b/api/src/main/java/jakarta/persistence/Column.java
@@ -186,4 +186,15 @@ public @interface Column {
      * @since 3.2
      */
     String comment() default "";
+
+    /**
+     * Determines if this column is validated as part of the
+     * schema {@linkplain SchemaManager#validate validation}
+     * process. By default, the column is validated. If the
+     * column should be excluded from validation, specify
+     * {@code validated=false}.
+     *
+     * @since 4.0
+     */
+    boolean validated() default true;
 }

--- a/api/src/main/java/jakarta/persistence/DiscriminatorColumn.java
+++ b/api/src/main/java/jakarta/persistence/DiscriminatorColumn.java
@@ -99,4 +99,15 @@ public @interface DiscriminatorColumn {
      * @since 4.0
      */
     String comment() default "";
+
+    /**
+     * Determines if this column is validated as part of the
+     * schema {@linkplain SchemaManager#validate validation}
+     * process. By default, the column is validated. If the
+     * column should be excluded from validation, specify
+     * {@code validated=false}.
+     *
+     * @since 4.0
+     */
+    boolean validated() default true;
 }

--- a/api/src/main/java/jakarta/persistence/JoinColumn.java
+++ b/api/src/main/java/jakarta/persistence/JoinColumn.java
@@ -212,4 +212,15 @@ public @interface JoinColumn {
      * @since 3.2
      */
     String comment() default "";
+
+    /**
+     * Determines if this column is validated as part of the
+     * schema {@linkplain SchemaManager#validate validation}
+     * process. By default, the column is validated. If the
+     * column should be excluded from validation, specify
+     * {@code validated=false}.
+     *
+     * @since 4.0
+     */
+    boolean validated() default true;
 }

--- a/api/src/main/java/jakarta/persistence/MapKeyColumn.java
+++ b/api/src/main/java/jakarta/persistence/MapKeyColumn.java
@@ -171,4 +171,15 @@ public @interface MapKeyColumn {
      * @since 4.0
      */
     String comment() default "";
+
+    /**
+     * Determines if this column is validated as part of the
+     * schema {@linkplain SchemaManager#validate validation}
+     * process. By default, the column is validated. If the
+     * column should be excluded from validation, specify
+     * {@code validated=false}.
+     *
+     * @since 4.0
+     */
+    boolean validated() default true;
 }

--- a/api/src/main/java/jakarta/persistence/MapKeyJoinColumn.java
+++ b/api/src/main/java/jakarta/persistence/MapKeyJoinColumn.java
@@ -228,4 +228,15 @@ public @interface MapKeyJoinColumn {
      * @since 3.2
      */
     String comment() default "";
+
+    /**
+     * Determines if this column is validated as part of the
+     * schema {@linkplain SchemaManager#validate validation}
+     * process. By default, the column is validated. If the
+     * column should be excluded from validation, specify
+     * {@code validated=false}.
+     *
+     * @since 4.0
+     */
+    boolean validated() default true;
 }

--- a/api/src/main/java/jakarta/persistence/OrderColumn.java
+++ b/api/src/main/java/jakarta/persistence/OrderColumn.java
@@ -117,4 +117,15 @@ public @interface OrderColumn {
      * @since 4.0
      */
     String comment() default "";
+
+    /**
+     * Determines if this column is validated as part of the
+     * schema {@linkplain SchemaManager#validate validation}
+     * process. By default, the column is validated. If the
+     * column should be excluded from validation, specify
+     * {@code validated=false}.
+     *
+     * @since 4.0
+     */
+    boolean validated() default true;
 }

--- a/api/src/main/java/jakarta/persistence/PrimaryKeyJoinColumn.java
+++ b/api/src/main/java/jakarta/persistence/PrimaryKeyJoinColumn.java
@@ -144,4 +144,15 @@ public @interface PrimaryKeyJoinColumn {
      * @since 4.0
      */
     String comment() default "";
+
+    /**
+     * Determines if this column is validated as part of the
+     * schema {@linkplain SchemaManager#validate validation}
+     * process. By default, the column is validated. If the
+     * column should be excluded from validation, specify
+     * {@code validated=false}.
+     *
+     * @since 4.0
+     */
+    boolean validated() default true;
 }


### PR DESCRIPTION
Sometimes users run into a case where the schema validation is too strict, and their program actually works as is; it's nice to have a way to exclude a column from validation.

Fixes #815.

WDYT?