### PR TITLE
jakarta.persistence.EntityListener XML declaration

### DIFF
--- a/api/src/main/resources/jakarta/persistence/persistence_4_0.xsd
+++ b/api/src/main/resources/jakarta/persistence/persistence_4_0.xsd
@@ -264,6 +264,17 @@
 
               <!-- **************************************************** -->
 
+              <xsd:element name="entity-listener" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                  <xsd:documentation>
+                    Names a jakarta.persistence.EntityListener class
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+
+              <!-- **************************************************** -->
+
               <xsd:element name="properties" minOccurs="0">
                 <xsd:annotation>
                   <xsd:documentation>

--- a/spec/src/main/asciidoc/ch08-entity-packaging.adoc
+++ b/spec/src/main/asciidoc/ch08-entity-packaging.adoc
@@ -522,6 +522,11 @@ The `default-to-one-fetch-type` element determines the default fetch
 type for one-to-one and many-to-one associations, as specified in
 <<fetching-policies>>.
 
+
+===== entity-listener
+
+The `entity-listener` element allows to specify zero-or-more `jakarta.persistence.EntityListener`-style listener classes.
+
 ===== properties [[a12384]]
 
 The `properties` element lists settings for both standard and


### PR DESCRIPTION
Possible solution to https://github.com/jakartaee/persistence/issues/1148.  This option uses in-line repeatable elements following the lead from other repeatable elements in this XSD.  E.g.

```xml
<persistence ...>
    <persistence-unit ....>
        <class>com.acme.A</class>
        <class>com.acme.B</class>

        ...

        <entity-listener>com.acme.Journaler</entity-listener>
        <entity-listener>com.acme.PermissionChecker</entity-listener>
    </persistence-unit>
</persistence>
```