### PR TITLE
remove <delimited-identifiers> from broken legacy TCK tests

### DIFF
--- a/tck/spec-tests/src/main/resources/ee/jakarta/tck/persistence/core/annotations/nativequery/orm.xml
+++ b/tck/spec-tests/src/main/resources/ee/jakarta/tck/persistence/core/annotations/nativequery/orm.xml
@@ -22,11 +22,6 @@
     xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence/orm
     https://jakarta.ee/xml/ns/persistence/orm/orm_4_0.xsd"
     version="4.0">
-    <persistence-unit-metadata>
-        <persistence-unit-defaults>
-            <delimited-identifiers/>
-        </persistence-unit-defaults>
-    </persistence-unit-metadata>
     <entity name="PurchaseOrder" class="ee.jakarta.tck.persistence.core.annotations.nativequery.PurchaseOrder" cacheable="true">
         <table name="PURCHASE_ORDER"/>
         <attributes>

--- a/tck/spec-tests/src/main/resources/ee/jakarta/tck/persistence/core/entitytest/apitests/orm.xml
+++ b/tck/spec-tests/src/main/resources/ee/jakarta/tck/persistence/core/entitytest/apitests/orm.xml
@@ -22,9 +22,4 @@
     xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence/orm
     https://jakarta.ee/xml/ns/persistence/orm/orm_4_0.xsd"
     version="4.0">
-    <persistence-unit-metadata>
-        <persistence-unit-defaults>
-            <delimited-identifiers/>
-        </persistence-unit-defaults>
-    </persistence-unit-metadata>
 </entity-mappings>


### PR DESCRIPTION
see #1175