### PR TITLE
remove use of Character[] and Byte[] as basic types from the TCK

### DIFF
--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/DataTypes.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/DataTypes.java
@@ -53,9 +53,9 @@ public class DataTypes implements java.io.Serializable {
 
 	private Grade enumData;
 
-	private Byte[] byteArrayData;
+	private byte[] byteArrayData;
 
-	private Character[] charArrayData;
+	private char[] charArrayData;
 
 	private String shouldNotPersist;
 
@@ -63,7 +63,7 @@ public class DataTypes implements java.io.Serializable {
 	}
 
 	public DataTypes(Integer id, Boolean booleanData, Character characterData, Short shortData, Integer integerData,
-			Long longData, Double doubleData, Float floatData, Character[] charArrayData, Byte[] byteArrayData) {
+			Long longData, Double doubleData, Float floatData, char[] charArrayData, byte[] byteArrayData) {
 		this.id = id;
 		this.booleanData = booleanData;
 		this.characterData = characterData;
@@ -82,7 +82,7 @@ public class DataTypes implements java.io.Serializable {
 		// these values can not be null because of postgres
 		this.characterData = new Character(' ');
 		this.characterData = ' ';
-		Byte[] bArray = { (byte) 32 };
+		byte[] bArray = { (byte) 32 };
 		this.byteArrayData = bArray;
 	}
 
@@ -175,21 +175,21 @@ public class DataTypes implements java.io.Serializable {
 	}
 
 	@Column(name = "CHARARRAYDATA")
-	public Character[] getCharArrayData() {
+	public char[] getCharArrayData() {
 		return charArrayData;
 	}
 
-	public void setCharArrayData(Character[] charArrayData) {
+	public void setCharArrayData(char[] charArrayData) {
 		this.charArrayData = charArrayData;
 	}
 
 	@Lob
 	@Column(name = "BYTEARRAYDATA")
-	public Byte[] getByteArrayData() {
+	public byte[] getByteArrayData() {
 		return byteArrayData;
 	}
 
-	public void setByteArrayData(Byte[] byteArrayData) {
+	public void setByteArrayData(byte[] byteArrayData) {
 		this.byteArrayData = byteArrayData;
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/PropertyAccessAnnotationPropertyTypeClient.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/PropertyAccessAnnotationPropertyTypeClient.java
@@ -490,16 +490,16 @@ public class PropertyAccessAnnotationPropertyTypeClient extends PropertyAccessAn
 	 * @assertion_ids: PERSISTENCE:SPEC:524; PERSISTENCE:SPEC:528
 	 * 
 	 * @test_Strategy: The persistent property of an entity may be of the following
-	 * type: Byte[]
+	 * type: byte[]
 	 *
 	 */
 	@Test
 	public void propertyTypeTest9() throws Exception {
 
 		boolean pass = false;
-		final Byte[] b = { 31, 32, 33, 63, 64, 65 };
-		final Byte bv = 5;
-		Byte[] a = null;
+		final byte[] b = { 31, 32, 33, 63, 64, 65 };
+		final byte bv = 5;
+		byte[] a = null;
 
 		try {
 			getEntityTransaction().begin();
@@ -523,10 +523,10 @@ public class PropertyAccessAnnotationPropertyTypeClient extends PropertyAccessAn
 					pass = true;
 				} else {
 					logger.log(Logger.Level.ERROR, "Unexpected result in array comparison.");
-					for (Byte aByte : a) {
+					for (byte aByte : a) {
 						logger.log(Logger.Level.TRACE, "Array a in propertyTest9 equals: " + aByte);
 					}
-					for (Byte bByte : b) {
+					for (byte bByte : b) {
 						logger.log(Logger.Level.TRACE, "Array b in propertyTest9 equals: " + bByte);
 					}
 					pass = false;
@@ -559,7 +559,7 @@ public class PropertyAccessAnnotationPropertyTypeClient extends PropertyAccessAn
 	 * @assertion_ids: PERSISTENCE:SPEC:524; PERSISTENCE:SPEC:528
 	 * 
 	 * @test_Strategy: The persistent property of an entity may be of the following
-	 * type: Character[]
+	 * type: char[]
 	 *
 	 */
 	@Test
@@ -569,7 +569,7 @@ public class PropertyAccessAnnotationPropertyTypeClient extends PropertyAccessAn
 
 		try {
 			getEntityTransaction().begin();
-			Character[] charData = new Character[] { (char) 'C', (char) 'T', (char) 'S' };
+			char[] charData = new char[] { 'C', 'T', 'S' };
 			clearCache();
 			d1 = null;
 			d1 = getEntityManager().find(DataTypes.class, 1);
@@ -783,8 +783,8 @@ public class PropertyAccessAnnotationPropertyTypeClient extends PropertyAccessAn
 
 		try {
 			getEntityTransaction().begin();
-			Character[] cArray = { 'a' };
-			Byte[] bArray = { (byte) 100 };
+			char[] cArray = { 'a' };
+			byte[] bArray = { (byte) 100 };
 			d1 = new DataTypes(1, true, 'a', (short) 100, 500, 300L, 50D, 1.0F, cArray, bArray);
 
 			d2 = new DataTypes2(dateId);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/A.java
@@ -85,13 +85,7 @@ public class A implements java.io.Serializable {
 	protected char[] basicCharArray;
 
 	@Basic
-	protected Character[] basicBigCharArray;
-
-	@Basic
 	protected byte[] basicByteArray;
-
-	@Basic
-	protected Byte[] basicBigByteArray;
 
 	@Basic
 	protected BigInteger basicBigInteger;
@@ -121,9 +115,9 @@ public class A implements java.io.Serializable {
 
 	public A(String id, String name, int value, Integer basicInteger, short basicShort, Short basicBigShort,
 			float basicFloat, Float basicBigFloat, long basicLong, Long basicBigLong, double basicDouble,
-			Double basicBigDouble, char basicChar, char[] basicCharArray, Character[] basicBigCharArray,
-			byte[] basicByteArray, Byte[] basicBigByteArray, BigInteger basicBigInteger, BigDecimal basicBigDecimal,
-			Date basicDate, Time basicTime, Timestamp basicTimestamp, Calendar basicCalendar) {
+			Double basicBigDouble, char basicChar, char[] basicCharArray, byte[] basicByteArray,
+			BigInteger basicBigInteger, BigDecimal basicBigDecimal, Date basicDate, Time basicTime,
+			Timestamp basicTimestamp, Calendar basicCalendar) {
 
 		this.id = id;
 		this.name = name;
@@ -139,9 +133,7 @@ public class A implements java.io.Serializable {
 		this.basicBigDouble = basicBigDouble;
 		this.basicChar = basicChar;
 		this.basicCharArray = basicCharArray;
-		this.basicBigCharArray = basicBigCharArray;
 		this.basicByteArray = basicByteArray;
-		this.basicBigByteArray = basicBigByteArray;
 		this.basicBigInteger = basicBigInteger;
 		this.basicBigDecimal = basicBigDecimal;
 		this.basicDate = basicDate;
@@ -237,22 +229,6 @@ public class A implements java.io.Serializable {
 
 	public void setBasicShort(short basicShort) {
 		this.basicShort = basicShort;
-	}
-
-	public Byte[] getBasicBigByteArray() {
-		return basicBigByteArray;
-	}
-
-	public void setBasicBigByteArray(Byte[] basicBigByteArray) {
-		this.basicBigByteArray = basicBigByteArray;
-	}
-
-	public Character[] getBasicBigCharArray() {
-		return basicBigCharArray;
-	}
-
-	public void setBasicBigCharArray(Character[] basicBigCharArray) {
-		this.basicBigCharArray = basicBigCharArray;
 	}
 
 	public BigDecimal getBasicBigDecimal() {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/BasicAnnotationClient.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/BasicAnnotationClient.java
@@ -46,9 +46,7 @@ public class BasicAnnotationClient extends PMClientBase {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -58,8 +56,8 @@ public class BasicAnnotationClient extends PMClientBase {
 			final Calendar calendar = Calendar.getInstance();
 
 			A aRef = new A("9", null, 9, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			getEntityManager().persist(aRef);
 			getEntityManager().flush();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/BasicAnnotationPersistBasicClient.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/BasicAnnotationPersistBasicClient.java
@@ -96,9 +96,7 @@ public class BasicAnnotationPersistBasicClient extends BasicAnnotationClient {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -108,8 +106,8 @@ public class BasicAnnotationPersistBasicClient extends BasicAnnotationClient {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("1", "a1", 1, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			getEntityTransaction().begin();
 			if (!getInstanceStatus(aRef)) {
@@ -175,9 +173,7 @@ public class BasicAnnotationPersistBasicClient extends BasicAnnotationClient {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -187,8 +183,8 @@ public class BasicAnnotationPersistBasicClient extends BasicAnnotationClient {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("2", "a2", 2, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			createA(aRef);
 
@@ -263,9 +259,7 @@ public class BasicAnnotationPersistBasicClient extends BasicAnnotationClient {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -275,8 +269,8 @@ public class BasicAnnotationPersistBasicClient extends BasicAnnotationClient {
 			final Calendar calendar = Calendar.getInstance();
 
 			a1 = new A("3", "a3", 3, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			logger.log(Logger.Level.TRACE, "Persist Instance");
 			getEntityManager().persist(a1);
@@ -348,9 +342,7 @@ public class BasicAnnotationPersistBasicClient extends BasicAnnotationClient {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -360,8 +352,8 @@ public class BasicAnnotationPersistBasicClient extends BasicAnnotationClient {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("4", "a4", 4, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			createA(aRef);
 
@@ -441,9 +433,7 @@ public class BasicAnnotationPersistBasicClient extends BasicAnnotationClient {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -453,8 +443,8 @@ public class BasicAnnotationPersistBasicClient extends BasicAnnotationClient {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("5", null, 5, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			logger.log(Logger.Level.TRACE, "Persist Instance");
 			createA(aRef);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/DataTypes.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/DataTypes.java
@@ -33,7 +33,7 @@ public class DataTypes implements java.io.Serializable {
 	@Lob
 	@Basic
 	@Column(name = "BYTEARRAYDATA")
-	protected Byte[] byteArrayData;
+	protected byte[] byteArrayData;
 
 	public DataTypes() {
 	}
@@ -42,7 +42,7 @@ public class DataTypes implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public DataTypes(int id, Byte[] byteArrayData) {
+	public DataTypes(int id, byte[] byteArrayData) {
 		this.id = id;
 		this.byteArrayData = byteArrayData;
 
@@ -52,11 +52,11 @@ public class DataTypes implements java.io.Serializable {
 		return id;
 	}
 
-	public Byte[] getByteArrayData() {
+	public byte[] getByteArrayData() {
 		return byteArrayData;
 	}
 
-	public void setByteArrayData(Byte[] byteArrayData) {
+	public void setByteArrayData(byte[] byteArrayData) {
 		this.byteArrayData = byteArrayData;
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/LobAnnotationClient.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/LobAnnotationClient.java
@@ -31,7 +31,7 @@ public class LobAnnotationClient extends PMClientBase {
 
 	private DataTypes dataTypes;
 
-	private Byte[] smallByteArray = null;
+	private byte[] smallByteArray = null;
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = LobAnnotationClient.class.getPackageName();
@@ -65,7 +65,7 @@ public class LobAnnotationClient extends PMClientBase {
 	 * @assertion_ids: PERSISTENCE:SPEC:524; PERSISTENCE:SPEC:528
 	 * 
 	 * @test_Strategy: The persistent property of an entity may be of the following
-	 * type: Byte[]
+	 * type: byte[]
 	 *
 	 */
 	@Test
@@ -74,7 +74,7 @@ public class LobAnnotationClient extends PMClientBase {
 		boolean pass1 = false;
 		boolean pass2 = false;
 
-		Byte[] largeByteArray = null;
+		byte[] largeByteArray = null;
 
 		try {
 			getEntityTransaction().begin();
@@ -148,7 +148,7 @@ public class LobAnnotationClient extends PMClientBase {
 
 	}
 
-	private Byte[] createSmallByteArray() {
+	private byte[] createSmallByteArray() {
 
 		// Create a String of size 1MB
 		StringBuffer strbuf = new StringBuffer();
@@ -160,19 +160,11 @@ public class LobAnnotationClient extends PMClientBase {
 		System.out.println("String Buffer :" + value);
 
 		// get byte array from the string
-		final byte myByte[] = value.getBytes();
-
-		// store primitive byte array to array of Byte objects
-		Byte convertedByte[] = new Byte[myByte.length];
-		for (int i = 0; i < myByte.length; i++) {
-			convertedByte[i] = Byte.valueOf(myByte[i]);
-		}
-
-		return convertedByte;
+		return value.getBytes();
 
 	}
 
-	private Byte[] createLargeByteArray() {
+	private byte[] createLargeByteArray() {
 
 		// Create a String of size 4MB
 		StringBuffer strbuf = new StringBuffer();
@@ -184,15 +176,7 @@ public class LobAnnotationClient extends PMClientBase {
 		System.out.println("String Buffer :" + value);
 
 		// get byte array from the string
-		final byte myByte[] = value.getBytes();
-
-		// store primitive byte array to array of Byte objects
-		Byte convertedByte[] = new Byte[myByte.length];
-		for (int i = 0; i < myByte.length; i++) {
-			convertedByte[i] = Byte.valueOf(myByte[i]);
-		}
-
-		return convertedByte;
+		return value.getBytes();
 
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/A.java
@@ -83,13 +83,7 @@ public class A implements java.io.Serializable {
 	protected char[] basicCharArray;
 
 	@Basic
-	protected Character[] basicBigCharArray;
-
-	@Basic
 	protected byte[] basicByteArray;
-
-	@Basic
-	protected Byte[] basicBigByteArray;
 
 	@Basic
 	protected BigInteger basicBigInteger;
@@ -121,9 +115,9 @@ public class A implements java.io.Serializable {
 
 	public A(String id, String name, int value, Integer basicInteger, short basicShort, Short basicBigShort,
 			float basicFloat, Float basicBigFloat, long basicLong, Long basicBigLong, double basicDouble,
-			Double basicBigDouble, char basicChar, char[] basicCharArray, Character[] basicBigCharArray,
-			byte[] basicByteArray, Byte[] basicBigByteArray, BigInteger basicBigInteger, BigDecimal basicBigDecimal,
-			Date basicDate, Time basicTime, Timestamp basicTimestamp, Calendar basicCalendar) {
+			Double basicBigDouble, char basicChar, char[] basicCharArray, byte[] basicByteArray,
+			BigInteger basicBigInteger, BigDecimal basicBigDecimal, Date basicDate, Time basicTime,
+			Timestamp basicTimestamp, Calendar basicCalendar) {
 
 		this.id = id;
 		this.name = name;
@@ -139,9 +133,7 @@ public class A implements java.io.Serializable {
 		this.basicBigDouble = basicBigDouble;
 		this.basicChar = basicChar;
 		this.basicCharArray = basicCharArray;
-		this.basicBigCharArray = basicBigCharArray;
 		this.basicByteArray = basicByteArray;
-		this.basicBigByteArray = basicBigByteArray;
 		this.basicBigInteger = basicBigInteger;
 		this.basicBigDecimal = basicBigDecimal;
 		this.basicDate = basicDate;
@@ -237,22 +229,6 @@ public class A implements java.io.Serializable {
 
 	public void setBasicShort(short basicShort) {
 		this.basicShort = basicShort;
-	}
-
-	public Byte[] getBasicBigByteArray() {
-		return basicBigByteArray;
-	}
-
-	public void setBasicBigByteArray(Byte[] basicBigByteArray) {
-		this.basicBigByteArray = basicBigByteArray;
-	}
-
-	public Character[] getBasicBigCharArray() {
-		return basicBigCharArray;
-	}
-
-	public void setBasicBigCharArray(Character[] basicBigCharArray) {
-		this.basicBigCharArray = basicBigCharArray;
 	}
 
 	public BigDecimal getBasicBigDecimal() {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/CriteriaQueryDoubleOperandResultTypeClient.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/CriteriaQueryDoubleOperandResultTypeClient.java
@@ -928,9 +928,7 @@ public class CriteriaQueryDoubleOperandResultTypeClient extends Util {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -940,8 +938,8 @@ public class CriteriaQueryDoubleOperandResultTypeClient extends Util {
 			final Calendar calendar = Calendar.getInstance();
 
 			A aRef = new A("9", null, 9, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			getEntityManager().persist(aRef);
 			getEntityManager().flush();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/CriteriaQueryMultiselectClient.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/CriteriaQueryMultiselectClient.java
@@ -1301,9 +1301,7 @@ public class CriteriaQueryMultiselectClient extends UtilCustomerData {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -1313,8 +1311,8 @@ public class CriteriaQueryMultiselectClient extends UtilCustomerData {
 			final Calendar calendar = Calendar.getInstance();
 
 			A aRef = new A("9", null, 9, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			getEntityManager().persist(aRef);
 			getEntityManager().flush();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/A.java
@@ -83,13 +83,7 @@ public class A implements java.io.Serializable {
 	protected char[] basicCharArray;
 
 	@Basic
-	protected Character[] basicBigCharArray;
-
-	@Basic
 	protected byte[] basicByteArray;
-
-	@Basic
-	protected Byte[] basicBigByteArray;
 
 	@Basic
 	protected BigInteger basicBigInteger;
@@ -119,9 +113,9 @@ public class A implements java.io.Serializable {
 
 	public A(String id, String name, int value, Integer basicInteger, short basicShort, Short basicBigShort,
 			float basicFloat, Float basicBigFloat, long basicLong, Long basicBigLong, double basicDouble,
-			Double basicBigDouble, char basicChar, char[] basicCharArray, Character[] basicBigCharArray,
-			byte[] basicByteArray, Byte[] basicBigByteArray, BigInteger basicBigInteger, BigDecimal basicBigDecimal,
-			Date basicDate, Time basicTime, Timestamp basicTimestamp, Calendar basicCalendar) {
+			Double basicBigDouble, char basicChar, char[] basicCharArray, byte[] basicByteArray,
+			BigInteger basicBigInteger, BigDecimal basicBigDecimal, Date basicDate, Time basicTime,
+			Timestamp basicTimestamp, Calendar basicCalendar) {
 
 		this.id = id;
 		this.name = name;
@@ -137,9 +131,7 @@ public class A implements java.io.Serializable {
 		this.basicBigDouble = basicBigDouble;
 		this.basicChar = basicChar;
 		this.basicCharArray = basicCharArray;
-		this.basicBigCharArray = basicBigCharArray;
 		this.basicByteArray = basicByteArray;
-		this.basicBigByteArray = basicBigByteArray;
 		this.basicBigInteger = basicBigInteger;
 		this.basicBigDecimal = basicBigDecimal;
 		this.basicDate = basicDate;
@@ -235,22 +227,6 @@ public class A implements java.io.Serializable {
 
 	public void setBasicShort(short basicShort) {
 		this.basicShort = basicShort;
-	}
-
-	public Byte[] getBasicBigByteArray() {
-		return basicBigByteArray;
-	}
-
-	public void setBasicBigByteArray(Byte[] basicBigByteArray) {
-		this.basicBigByteArray = basicBigByteArray;
-	}
-
-	public Character[] getBasicBigCharArray() {
-		return basicBigCharArray;
-	}
-
-	public void setBasicBigCharArray(Character[] basicBigCharArray) {
-		this.basicBigCharArray = basicBigCharArray;
 	}
 
 	public BigDecimal getBasicBigDecimal() {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/BigDecimalEntityClient.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/BigDecimalEntityClient.java
@@ -99,9 +99,7 @@ public class BigDecimalEntityClient extends PMClientBase {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -111,8 +109,8 @@ public class BigDecimalEntityClient extends PMClientBase {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("1", "a1", 1, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			getEntityTransaction().begin();
 			if (!getInstanceStatus(aRef)) {
@@ -178,9 +176,7 @@ public class BigDecimalEntityClient extends PMClientBase {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -190,8 +186,8 @@ public class BigDecimalEntityClient extends PMClientBase {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("2", "a2", 2, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			createA(aRef);
 
@@ -266,9 +262,7 @@ public class BigDecimalEntityClient extends PMClientBase {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -278,8 +272,8 @@ public class BigDecimalEntityClient extends PMClientBase {
 			final Calendar calendar = Calendar.getInstance();
 
 			a1 = new A("3", "a3", 3, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			logger.log(Logger.Level.TRACE, "Persist Instance");
 			getEntityManager().persist(a1);
@@ -351,9 +345,7 @@ public class BigDecimalEntityClient extends PMClientBase {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -363,8 +355,8 @@ public class BigDecimalEntityClient extends PMClientBase {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("4", "a4", 4, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			createA(aRef);
 
@@ -445,9 +437,7 @@ public class BigDecimalEntityClient extends PMClientBase {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -457,8 +447,8 @@ public class BigDecimalEntityClient extends PMClientBase {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("5", "a5", 5, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			logger.log(Logger.Level.TRACE, "Persist Instance");
 			createA(aRef);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/A.java
@@ -83,13 +83,7 @@ public class A implements java.io.Serializable {
 	protected char[] basicCharArray;
 
 	@Basic
-	protected Character[] basicBigCharArray;
-
-	@Basic
 	protected byte[] basicByteArray;
-
-	@Basic
-	protected Byte[] basicBigByteArray;
 
 	@Id
 	protected BigInteger basicBigInteger;
@@ -119,9 +113,9 @@ public class A implements java.io.Serializable {
 
 	public A(String id, String name, int value, Integer basicInteger, short basicShort, Short basicBigShort,
 			float basicFloat, Float basicBigFloat, long basicLong, Long basicBigLong, double basicDouble,
-			Double basicBigDouble, char basicChar, char[] basicCharArray, Character[] basicBigCharArray,
-			byte[] basicByteArray, Byte[] basicBigByteArray, BigInteger basicBigInteger, BigDecimal basicBigDecimal,
-			Date basicDate, Time basicTime, Timestamp basicTimestamp, Calendar basicCalendar) {
+			Double basicBigDouble, char basicChar, char[] basicCharArray, byte[] basicByteArray,
+			BigInteger basicBigInteger, BigDecimal basicBigDecimal, Date basicDate, Time basicTime,
+			Timestamp basicTimestamp, Calendar basicCalendar) {
 
 		this.id = id;
 		this.name = name;
@@ -137,9 +131,7 @@ public class A implements java.io.Serializable {
 		this.basicBigDouble = basicBigDouble;
 		this.basicChar = basicChar;
 		this.basicCharArray = basicCharArray;
-		this.basicBigCharArray = basicBigCharArray;
 		this.basicByteArray = basicByteArray;
-		this.basicBigByteArray = basicBigByteArray;
 		this.basicBigInteger = basicBigInteger;
 		this.basicBigDecimal = basicBigDecimal;
 		this.basicDate = basicDate;
@@ -235,22 +227,6 @@ public class A implements java.io.Serializable {
 
 	public void setBasicShort(short basicShort) {
 		this.basicShort = basicShort;
-	}
-
-	public Byte[] getBasicBigByteArray() {
-		return basicBigByteArray;
-	}
-
-	public void setBasicBigByteArray(Byte[] basicBigByteArray) {
-		this.basicBigByteArray = basicBigByteArray;
-	}
-
-	public Character[] getBasicBigCharArray() {
-		return basicBigCharArray;
-	}
-
-	public void setBasicBigCharArray(Character[] basicBigCharArray) {
-		this.basicBigCharArray = basicBigCharArray;
 	}
 
 	public BigDecimal getBasicBigDecimal() {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/BigIntegerEntityClient.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/BigIntegerEntityClient.java
@@ -99,9 +99,7 @@ public class BigIntegerEntityClient extends PMClientBase {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -111,8 +109,8 @@ public class BigIntegerEntityClient extends PMClientBase {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("1", "a1", 1, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			getEntityTransaction().begin();
 			if (!getInstanceStatus(aRef)) {
@@ -178,9 +176,7 @@ public class BigIntegerEntityClient extends PMClientBase {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -190,8 +186,8 @@ public class BigIntegerEntityClient extends PMClientBase {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("2", "a2", 2, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			createA(aRef);
 
@@ -265,9 +261,7 @@ public class BigIntegerEntityClient extends PMClientBase {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -277,8 +271,8 @@ public class BigIntegerEntityClient extends PMClientBase {
 			final Calendar calendar = Calendar.getInstance();
 
 			a1 = new A("3", "a3", 3, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			logger.log(Logger.Level.TRACE, "Persist Instance");
 			getEntityManager().persist(a1);
@@ -350,9 +344,7 @@ public class BigIntegerEntityClient extends PMClientBase {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -362,8 +354,8 @@ public class BigIntegerEntityClient extends PMClientBase {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("4", "a4", 4, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			createA(aRef);
 
@@ -444,9 +436,7 @@ public class BigIntegerEntityClient extends PMClientBase {
 			final double basicDouble = 1234.5;
 			final Double basicBigDouble = basicDouble;
 			final char[] charArray = { 'a', 'b', 'c' };
-			final Character[] bigCharacterArray = { 'a', 'b', 'c' };
 			final byte[] byteArray = "abc".getBytes();
-			final Byte[] bigByteArray = { (byte) 111, (byte) 101, (byte) 100 };
 			final BigInteger bigInteger = new BigInteger("12345");
 			final BigDecimal bigDecimal = new BigDecimal(bigInteger);
 			final Date date = new Date();
@@ -456,8 +446,8 @@ public class BigIntegerEntityClient extends PMClientBase {
 			final Calendar calendar = Calendar.getInstance();
 
 			aRef = new A("5", "a5", 5, integer, basicShort, basicBigShort, basicFloat, basicBigFloat, basicLong,
-					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, bigCharacterArray, byteArray,
-					bigByteArray, bigInteger, bigDecimal, date, time, timeStamp, calendar);
+					basicBigLong, basicDouble, basicBigDouble, 'a', charArray, byteArray, bigInteger, bigDecimal,
+					date, time, timeStamp, calendar);
 
 			logger.log(Logger.Level.TRACE, "Persist Instance");
 			createA(aRef);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/DataTypes.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/DataTypes.java
@@ -52,15 +52,15 @@ public class DataTypes implements java.io.Serializable {
 
 	private Grade enumData;
 
-	private Byte[] byteArrayData;
+	private byte[] byteArrayData;
 
-	private Character[] charArrayData;
+	private char[] charArrayData;
 
 	public DataTypes() {
 	}
 
 	public DataTypes(Integer id, Character characterData, Boolean booleanData, Short shortData, Integer integerData,
-			Long longData, Double doubleData, Float floatData, Character[] charArrayData, Byte[] byteArrayData) {
+			Long longData, Double doubleData, Float floatData, char[] charArrayData, byte[] byteArrayData) {
 		this.id = id;
 		this.characterData = characterData;
 		this.booleanData = booleanData;
@@ -158,21 +158,21 @@ public class DataTypes implements java.io.Serializable {
 	}
 
 	@Column(name = "CHARARRAYDATA")
-	public Character[] getCharArrayData() {
+	public char[] getCharArrayData() {
 		return charArrayData;
 	}
 
-	public void setCharArrayData(Character[] charArrayData) {
+	public void setCharArrayData(char[] charArrayData) {
 		this.charArrayData = charArrayData;
 	}
 
 	@Lob
 	@Column(name = "BYTEARRAYDATA")
-	public Byte[] getByteArrayData() {
+	public byte[] getByteArrayData() {
 		return byteArrayData;
 	}
 
-	public void setByteArrayData(Byte[] byteArrayData) {
+	public void setByteArrayData(byte[] byteArrayData) {
 		this.byteArrayData = byteArrayData;
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/PropertyTypePropertyTypeClient.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/PropertyTypePropertyTypeClient.java
@@ -505,16 +505,16 @@ public class PropertyTypePropertyTypeClient extends PMClientBase {
 	 * PERSISTENCE:SPEC:1976;
 	 * 
 	 * @test_Strategy: The persistent property of an entity may be of the following
-	 * type: Byte[]
+	 * type: byte[]
 	 *
 	 */
 	@Test
 	public void propertyTypeTest9() throws Exception {
 
 		boolean pass = false;
-		final Byte[] b = { 31, 32, 33, 63, 64, 65 };
-		final Byte bv = 5;
-		Byte[] a = null;
+		final byte[] b = { 31, 32, 33, 63, 64, 65 };
+		final byte bv = 5;
+		byte[] a = null;
 
 		try {
 			getEntityTransaction().begin();
@@ -574,7 +574,7 @@ public class PropertyTypePropertyTypeClient extends PMClientBase {
 	 * PERSISTENCE:SPEC:1976;
 	 * 
 	 * @test_Strategy: The persistent property of an entity may be of the following
-	 * type: Character[]
+	 * type: char[]
 	 *
 	 */
 	@Test
@@ -584,7 +584,7 @@ public class PropertyTypePropertyTypeClient extends PMClientBase {
 
 		try {
 			getEntityTransaction().begin();
-			Character[] charData = new Character[] { 'C', 'T', 'S' };
+			char[] charData = new char[] { 'C', 'T', 'S' };
 			logger.log(Logger.Level.TRACE, "FIND D1 IN propertyTypeTest10");
 			d1 = getEntityManager().find(DataTypes.class, 1);
 
@@ -898,8 +898,8 @@ public class PropertyTypePropertyTypeClient extends PMClientBase {
 		try {
 			getEntityTransaction().begin();
 
-			Character[] cArray = { 'a' };
-			Byte[] bArray = { (byte) 100 };
+			char[] cArray = { 'a' };
+			byte[] bArray = { (byte) 100 };
 			d1 = new DataTypes(1, 'a', true, (short) 100, 500, 300L, 50D, 1.0F, cArray, bArray);
 			d1.setEnumData(Grade.C);
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/A.java
@@ -85,13 +85,7 @@ public class A implements java.io.Serializable {
 	protected char[] basicCharArray;
 
 	@Basic
-	protected Character[] basicBigCharArray;
-
-	@Basic
 	protected byte[] basicByteArray;
-
-	@Basic
-	protected Byte[] basicBigByteArray;
 
 	@Basic
 	protected BigInteger basicBigInteger;
@@ -121,9 +115,9 @@ public class A implements java.io.Serializable {
 
 	public A(String id, String name, int value, Integer basicInteger, short basicShort, Short basicBigShort,
 			float basicFloat, Float basicBigFloat, long basicLong, Long basicBigLong, double basicDouble,
-			Double basicBigDouble, char basicChar, char[] basicCharArray, Character[] basicBigCharArray,
-			byte[] basicByteArray, Byte[] basicBigByteArray, BigInteger basicBigInteger, BigDecimal basicBigDecimal,
-			Date basicDate, Time basicTime, Timestamp basicTimestamp, Calendar basicCalendar) {
+			Double basicBigDouble, char basicChar, char[] basicCharArray, byte[] basicByteArray,
+			BigInteger basicBigInteger, BigDecimal basicBigDecimal, Date basicDate, Time basicTime,
+			Timestamp basicTimestamp, Calendar basicCalendar) {
 
 		this.id = id;
 		this.name = name;
@@ -139,9 +133,7 @@ public class A implements java.io.Serializable {
 		this.basicBigDouble = basicBigDouble;
 		this.basicChar = basicChar;
 		this.basicCharArray = basicCharArray;
-		this.basicBigCharArray = basicBigCharArray;
 		this.basicByteArray = basicByteArray;
-		this.basicBigByteArray = basicBigByteArray;
 		this.basicBigInteger = basicBigInteger;
 		this.basicBigDecimal = basicBigDecimal;
 		this.basicDate = basicDate;
@@ -237,22 +229,6 @@ public class A implements java.io.Serializable {
 
 	public void setBasicShort(short basicShort) {
 		this.basicShort = basicShort;
-	}
-
-	public Byte[] getBasicBigByteArray() {
-		return basicBigByteArray;
-	}
-
-	public void setBasicBigByteArray(Byte[] basicBigByteArray) {
-		this.basicBigByteArray = basicBigByteArray;
-	}
-
-	public Character[] getBasicBigCharArray() {
-		return basicBigCharArray;
-	}
-
-	public void setBasicBigCharArray(Character[] basicBigCharArray) {
-		this.basicBigCharArray = basicBigCharArray;
 	}
 
 	public BigDecimal getBasicBigDecimal() {


### PR DESCRIPTION
fixes #792

Follow-up to #791, which dropped `Character[]` and `Byte[]` from the list of basic types in 4.0.

- The tests that specifically exercised `Byte[]` and `Character[]` properties (`propertyTypeTest9`/`propertyTypeTest10` in `core.types.property` and in `core.annotations.access.property`, and `lobTest` in `core.annotations.lob`) now exercise `byte[]` and `char[]` instead, mirroring the existing field-access variants (`fieldTypeTest11`/`fieldTypeTest12`). Property access previously had no coverage for primitive arrays at all, so this keeps that coverage rather than simply deleting the tests. The mapped columns (`BYTEARRAYDATA`, `CHARARRAYDATA`) are unchanged.
- The `A` entities in `core.annotations.basic`, `core.criteriaapi.CriteriaQuery`, `core.entitytest.bigdecimal`, `core.entitytest.biginteger` and `se.entityManager` declared `Character[]`/`Byte[]` attributes alongside their `char[]`/`byte[]` attributes. No test ever read them back, so they are removed, along with the corresponding constructor parameters and the arguments passed by the test clients. The `BASICBIGCHARARRAY`/`BASICBIGBYTEARRAY` columns of `A_BASIC`, `A_BIGDECIMAL` and `A_BIGINTEGER` are now simply unused.

No test names or assertion ids change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
